### PR TITLE
Add light/dark mode toggle with OS preference detection

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -4,19 +4,67 @@
   <title>Terminal</title>
   <link rel="stylesheet" href="/static/lib/xterm.css">
   <style>
-    body { margin: 0; background: #1e1e1e; color: #fff; font-family: monospace; }
+    body { margin: 0; font-family: monospace; transition: background 0.3s, color 0.3s; }
+    body.dark { background: #1e1e1e; color: #fff; }
+    body.light { background: #f5f5f5; color: #383a42; }
     #terminal { height: 100vh; width: 100vw; }
     #status { position: absolute; top: 10px; left: 10px; z-index: 1000; }
+    #theme-toggle {
+      position: fixed; top: 10px; right: 10px; z-index: 1000;
+      background: none; border: 1px solid rgba(128,128,128,0.4); border-radius: 6px;
+      padding: 4px 8px; cursor: pointer; font-size: 18px; line-height: 1;
+      transition: border-color 0.3s;
+    }
+    #theme-toggle:hover { border-color: rgba(128,128,128,0.8); }
   </style>
 </head>
 <body>
   <div id="status">Loading...</div>
+  <button id="theme-toggle" title="Toggle light/dark mode"></button>
   <div id="terminal"></div>
 
   <script src="/static/lib/xterm.js"></script>
   <script src="/static/lib/addon-fit.js"></script>
   <script src="/static/lib/addon-web-links.js"></script>
   <script>
+    const darkTheme = {
+      background: '#1e1e1e', foreground: '#d4d4d4', cursor: '#d4d4d4',
+      selectionBackground: '#264f78',
+      black: '#1e1e1e', red: '#f44747', green: '#6a9955', yellow: '#d7ba7d',
+      blue: '#569cd6', magenta: '#c586c0', cyan: '#4ec9b0', white: '#d4d4d4'
+    };
+    const lightTheme = {
+      background: '#f5f5f5', foreground: '#383a42', cursor: '#526eff',
+      selectionBackground: '#d7d7ff',
+      black: '#383a42', red: '#e45649', green: '#50a14f', yellow: '#c18401',
+      blue: '#4078f2', magenta: '#a626a4', cyan: '#0184bc', white: '#fafafa'
+    };
+
+    function getPreferredMode() {
+      const saved = localStorage.getItem('terminal-theme');
+      if (saved) return saved;
+      return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+    }
+
+    let currentMode = getPreferredMode();
+    let termInstance = null;
+
+    function applyTheme(mode) {
+      currentMode = mode;
+      document.body.className = mode;
+      document.getElementById('theme-toggle').textContent = mode === 'dark' ? '\u2600\uFE0F' : '\uD83C\uDF19';
+      if (termInstance) {
+        termInstance.options.theme = mode === 'dark' ? darkTheme : lightTheme;
+      }
+      localStorage.setItem('terminal-theme', mode);
+    }
+
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      applyTheme(currentMode === 'dark' ? 'light' : 'dark');
+    });
+
+    applyTheme(currentMode);
+
     const status = document.getElementById('status');
     let sessionId = null;
     let pollInterval = null;
@@ -98,8 +146,9 @@
         // Initialize terminal
         const term = new Terminal({
           cursorBlink: true,
-          theme: { background: '#1e1e1e' }
+          theme: currentMode === 'dark' ? darkTheme : lightTheme
         });
+        termInstance = term;
         const fitAddon = new FitAddon.FitAddon();
         const webLinksAddon = new WebLinksAddon.WebLinksAddon();
         term.loadAddon(fitAddon);


### PR DESCRIPTION
## Summary
- Auto-detects OS light/dark preference via `prefers-color-scheme` media query
- Adds toggle button (sun/moon icon) in top-right corner to switch themes
- Full xterm.js color palettes for both dark and light modes
- Persists user choice in `localStorage` across sessions

Fixes #15

## Test plan
- [x] Verified locally — toggle works, themes apply correctly, persists across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)