### PR TITLE
Add CoDA landing page for GitHub Pages

### DIFF
--- a/site/assets/index.html
+++ b/site/assets/index.html
@@ -1,0 +1,804 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CoDA — Co-Working Developer Agents on Databricks Apps</title>
+  <meta name="description" content="Four AI coding agents running in one Databricks App. Claude Code, Codex, Gemini CLI, and OpenCode — configured for your lakehouse out of the box.">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@0.344.0/dist/umd/lucide.min.js"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            'surface-0': '#090b0f',
+            'surface-1': '#12141a',
+            'surface-2': '#1a1d25',
+            'surface-3': '#22252f',
+            'db-orange': '#FF3621',
+            'db-light': '#ff6b4a',
+          },
+          fontFamily: {
+            sans: ['Inter', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'Fira Code', 'monospace'],
+          }
+        }
+      }
+    }
+  </script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: #090b0f;
+      color: #b4bcd0;
+      overflow-x: hidden;
+    }
+
+    /* ===== GRADIENT TEXT ===== */
+    .gradient-text {
+      background: linear-gradient(135deg, #FF3621, #ff6b4a);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    /* ===== SOLID CARDS (no glassmorphism) ===== */
+    .card {
+      background: #12141a;
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 12px;
+      transition: border-color 0.2s ease;
+    }
+    .card:hover {
+      border-color: rgba(255, 255, 255, 0.12);
+    }
+
+    /* ===== AGENT CARD HOVER ===== */
+    .agent-claude { --agent-color: 204, 120, 50; }
+    .agent-codex { --agent-color: 16, 163, 127; }
+    .agent-gemini { --agent-color: 66, 133, 244; }
+    .agent-opencode { --agent-color: 168, 85, 247; }
+    [class*="agent-"]:hover {
+      border-color: rgba(var(--agent-color), 0.3);
+    }
+
+    /* ===== TERMINAL ===== */
+    .terminal {
+      background: #12141a;
+      border-radius: 12px;
+      border: 1px solid rgba(255,255,255,0.08);
+      overflow: hidden;
+      font-family: 'JetBrains Mono', monospace;
+    }
+    .terminal-bar {
+      background: #0d0f14;
+      padding: 12px 18px;
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      border-bottom: 1px solid rgba(255,255,255,0.05);
+    }
+    .terminal-dot { width: 12px; height: 12px; border-radius: 50%; }
+    .terminal-tabs {
+      display: flex;
+      gap: 2px;
+      margin-left: 20px;
+      overflow-x: auto;
+    }
+    .terminal-tab {
+      padding: 5px 14px;
+      border-radius: 6px;
+      font-size: 11px;
+      color: rgba(255,255,255,0.35);
+      cursor: pointer;
+      transition: color 0.2s, background 0.2s;
+      white-space: nowrap;
+    }
+    .terminal-tab:hover { color: rgba(255,255,255,0.6); }
+    .terminal-tab.active {
+      background: rgba(255,255,255,0.06);
+      color: #e2e8f0;
+    }
+    .terminal-body {
+      padding: 24px;
+      min-height: 200px;
+      font-size: 13px;
+      line-height: 1.8;
+    }
+    .cursor-blink {
+      display: inline-block;
+      width: 8px; height: 18px;
+      background: #FF3621;
+      animation: blink 1s step-end infinite;
+      vertical-align: text-bottom;
+      border-radius: 1px;
+    }
+    @keyframes blink { 50% { opacity: 0; } }
+
+    /* ===== SCROLL FADE-IN (only animation) ===== */
+    .fade-in {
+      opacity: 0;
+      transform: translateY(24px);
+      transition: opacity 0.5s ease, transform 0.5s ease;
+    }
+    .fade-in.visible { opacity: 1; transform: translateY(0); }
+
+    /* ===== CTA BUTTONS ===== */
+    .cta-primary {
+      background: #FF3621;
+      transition: filter 0.2s, transform 0.2s;
+    }
+    .cta-primary:hover {
+      filter: brightness(1.15);
+      transform: translateY(-1px);
+    }
+    .cta-secondary {
+      border: 1px solid rgba(255,255,255,0.12);
+      transition: border-color 0.2s;
+    }
+    .cta-secondary:hover {
+      border-color: rgba(255,255,255,0.25);
+    }
+
+    /* ===== STEP NUMBERS ===== */
+    .step-number {
+      width: 48px; height: 48px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 18px;
+      font-weight: 700;
+      background: #FF3621;
+      color: white;
+      flex-shrink: 0;
+    }
+
+    /* ===== SECTION DIVIDER ===== */
+    .section-divider {
+      height: 1px;
+      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.04), transparent);
+    }
+
+    /* ===== NAVBAR ===== */
+    .navbar {
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      z-index: 100;
+      padding: 14px 24px;
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      background: rgba(9, 11, 15, 0.8);
+      border-bottom: 1px solid rgba(255,255,255,0.04);
+      transition: padding 0.2s;
+    }
+    .navbar.scrolled { padding: 10px 24px; }
+
+    /* ===== ICON CONTAINER ===== */
+    .icon-box {
+      width: 40px; height: 40px;
+      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    /* ===== REDUCED MOTION ===== */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    /* ===== MOBILE ===== */
+    @media (max-width: 640px) {
+      .terminal-tabs { gap: 0; }
+      .terminal-tab { padding: 5px 10px; font-size: 10px; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Subtle grid background (CSS-only, no canvas) -->
+  <svg class="fixed inset-0 w-full h-full pointer-events-none z-0" xmlns="http://www.w3.org/2000/svg">
+    <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+      <path d="M 60 0 L 0 0 0 60" fill="none" stroke="rgba(255,255,255,0.02)" stroke-width="0.5"/>
+    </pattern>
+    <rect width="100%" height="100%" fill="url(#grid)"/>
+  </svg>
+
+  <!-- ===== NAVBAR ===== -->
+  <nav class="navbar" id="navbar">
+    <div class="max-w-5xl mx-auto flex items-center justify-between">
+      <a href="#hero" class="flex items-center gap-2.5">
+        <span class="text-white font-bold text-lg tracking-tight">CoDA</span>
+      </a>
+      <div class="hidden md:flex items-center gap-8">
+        <a href="#agents" class="text-gray-400 hover:text-white text-sm transition-colors">Agents</a>
+        <a href="#features" class="text-gray-400 hover:text-white text-sm transition-colors">Features</a>
+        <a href="#platform" class="text-gray-400 hover:text-white text-sm transition-colors">Platform</a>
+        <a href="#deploy" class="text-gray-400 hover:text-white text-sm transition-colors">Deploy</a>
+        <a href="https://github.com/datasciencemonkey/coding-agents-databricks-apps" target="_blank"
+           class="cta-primary px-4 py-2 rounded-lg text-white text-sm font-semibold inline-flex items-center gap-2">
+          <i data-lucide="github" class="w-4 h-4"></i> GitHub
+        </a>
+      </div>
+      <!-- Mobile menu button -->
+      <button id="mobile-menu-btn" class="md:hidden text-gray-400 p-2" aria-label="Toggle menu">
+        <i data-lucide="menu" class="w-5 h-5"></i>
+      </button>
+    </div>
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="hidden md:hidden pt-4 pb-2 border-t border-white/5 mt-3">
+      <div class="flex flex-col gap-3">
+        <a href="#agents" class="text-gray-400 hover:text-white text-sm">Agents</a>
+        <a href="#features" class="text-gray-400 hover:text-white text-sm">Features</a>
+        <a href="#platform" class="text-gray-400 hover:text-white text-sm">Platform</a>
+        <a href="#deploy" class="text-gray-400 hover:text-white text-sm">Deploy</a>
+      </div>
+    </div>
+  </nav>
+
+  <!-- ============================================================ -->
+  <!-- HERO                                                          -->
+  <!-- ============================================================ -->
+  <section id="hero" class="relative min-h-screen flex items-center justify-center px-4 pt-20 pb-16">
+    <!-- Single ambient glow (one, not three) -->
+    <div class="absolute top-1/4 left-1/2 -translate-x-1/2 w-[600px] h-[400px] rounded-full pointer-events-none" style="background:radial-gradient(circle,rgba(255,54,33,0.06),transparent 70%);filter:blur(40px);"></div>
+
+    <div class="relative z-10 max-w-4xl mx-auto text-center">
+      <h1 class="text-6xl md:text-8xl font-extrabold tracking-tight leading-none mb-6 gradient-text">CoDA</h1>
+      <p class="text-sm text-gray-500 font-medium tracking-[0.25em] uppercase mb-10">Co-Working Developer Agents</p>
+
+      <p class="text-xl md:text-3xl font-semibold text-white mb-4 leading-snug">
+        Four AI coding agents.<br class="hidden sm:block">
+        <span class="gradient-text">One Databricks App.</span> Three steps to running.
+      </p>
+      <p class="text-base text-gray-400 mb-12 max-w-xl mx-auto">
+        Claude Code, Codex, Gemini CLI, and OpenCode — configured for Unity Catalog, AI Gateway, and Workspace files out of the box.
+      </p>
+
+      <div class="flex flex-col sm:flex-row gap-3 justify-center mb-16">
+        <a href="https://github.com/datasciencemonkey/coding-agents-databricks-apps" target="_blank"
+           class="cta-primary px-7 py-3.5 rounded-xl text-white font-semibold text-sm inline-flex items-center justify-center gap-2">
+          <i data-lucide="github" class="w-4 h-4"></i> Fork on GitHub
+        </a>
+        <a href="#agents"
+           class="cta-secondary px-7 py-3.5 rounded-xl text-gray-300 font-medium text-sm inline-flex items-center justify-center gap-2">
+          See how it works
+        </a>
+      </div>
+
+      <!-- Terminal Mockup -->
+      <div class="terminal max-w-2xl mx-auto text-left fade-in">
+        <div class="terminal-bar">
+          <div class="terminal-dot" style="background:#ff5f57"></div>
+          <div class="terminal-dot" style="background:#febc2e"></div>
+          <div class="terminal-dot" style="background:#28c840"></div>
+          <div class="terminal-tabs" role="tablist">
+            <button class="terminal-tab active" role="tab" aria-selected="true" data-agent="claude">
+              <span style="color:#cc7832;">&#9679;</span> Claude Code
+            </button>
+            <button class="terminal-tab" role="tab" aria-selected="false" data-agent="codex">
+              <span style="color:#10a37f;">&#9679;</span> Codex
+            </button>
+            <button class="terminal-tab" role="tab" aria-selected="false" data-agent="gemini">
+              <span style="color:#4285f4;">&#9679;</span> Gemini CLI
+            </button>
+            <button class="terminal-tab" role="tab" aria-selected="false" data-agent="opencode">
+              <span style="color:#a855f7;">&#9679;</span> OpenCode
+            </button>
+          </div>
+        </div>
+        <div class="terminal-body">
+          <div class="text-gray-600 text-xs mb-3">~/workspace/project</div>
+          <div id="terminal-output" class="text-green-400"></div>
+          <span class="cursor-blink"></span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ============================================================ -->
+  <!-- AGENTS (moved up — show the product first)                    -->
+  <!-- ============================================================ -->
+  <section id="agents" class="relative z-10 py-24 px-4">
+    <div class="max-w-5xl mx-auto">
+      <div class="text-center mb-14 fade-in">
+        <p class="text-db-orange text-xs font-semibold tracking-widest uppercase mb-3">Four Agents, One Terminal</p>
+        <h2 class="text-3xl md:text-4xl font-bold text-white">Pick the right model for the job</h2>
+        <p class="text-gray-400 mt-4 max-w-lg mx-auto">Different models see different things. Switch agents with a click — they share the same workspace, the same data, the same Databricks context.</p>
+      </div>
+
+      <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-4 fade-in">
+        <!-- Claude Code -->
+        <div class="card agent-claude p-6">
+          <div class="flex items-center gap-3 mb-4">
+            <div class="icon-box" style="background:rgba(204,120,50,0.1)">
+              <i data-lucide="brain" class="w-5 h-5" style="color:#cc7832"></i>
+            </div>
+            <div>
+              <h3 class="text-sm font-semibold text-white">Claude Code</h3>
+              <p class="text-xs text-gray-500">Anthropic</p>
+            </div>
+          </div>
+          <p class="text-xs text-gray-500 font-mono mb-3">databricks-claude-opus-4-6</p>
+          <p class="text-gray-400 text-sm leading-relaxed">Deep Databricks skills + useful MCP servers. The most deeply integrated agent.</p>
+        </div>
+
+        <!-- Codex -->
+        <div class="card agent-codex p-6">
+          <div class="flex items-center gap-3 mb-4">
+            <div class="icon-box" style="background:rgba(16,163,127,0.1)">
+              <i data-lucide="code" class="w-5 h-5" style="color:#10a37f"></i>
+            </div>
+            <div>
+              <h3 class="text-sm font-semibold text-white">Codex</h3>
+              <p class="text-xs text-gray-500">OpenAI</p>
+            </div>
+          </div>
+          <p class="text-xs text-gray-500 font-mono mb-3">databricks-codex</p>
+          <p class="text-gray-400 text-sm leading-relaxed">OpenAI's reasoning engine. Excels at multi-step code generation and refactoring.</p>
+        </div>
+
+        <!-- Gemini CLI -->
+        <div class="card agent-gemini p-6">
+          <div class="flex items-center gap-3 mb-4">
+            <div class="icon-box" style="background:rgba(66,133,244,0.1)">
+              <i data-lucide="sparkles" class="w-5 h-5" style="color:#4285f4"></i>
+            </div>
+            <div>
+              <h3 class="text-sm font-semibold text-white">Gemini CLI</h3>
+              <p class="text-xs text-gray-500">Google</p>
+            </div>
+          </div>
+          <p class="text-xs text-gray-500 font-mono mb-3">databricks-gemini-2.5-pro</p>
+          <p class="text-gray-400 text-sm leading-relaxed">Google's multimodal agent. Vision, long context, and deep reasoning.</p>
+        </div>
+
+        <!-- OpenCode -->
+        <div class="card agent-opencode p-6">
+          <div class="flex items-center gap-3 mb-4">
+            <div class="icon-box" style="background:rgba(168,85,247,0.1)">
+              <i data-lucide="terminal" class="w-5 h-5" style="color:#a855f7"></i>
+            </div>
+            <div>
+              <h3 class="text-sm font-semibold text-white">OpenCode</h3>
+              <p class="text-xs text-gray-500">Open Source</p>
+            </div>
+          </div>
+          <p class="text-xs text-gray-500 font-mono mb-3">multi-provider</p>
+          <p class="text-gray-400 text-sm leading-relaxed">Open-source, multi-provider. Use any model, any backend, full transparency.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ============================================================ -->
+  <!-- FEATURES                                                      -->
+  <!-- ============================================================ -->
+  <section id="features" class="relative z-10 py-24 px-4">
+    <div class="max-w-5xl mx-auto">
+      <div class="text-center mb-14 fade-in">
+        <p class="text-db-orange text-xs font-semibold tracking-widest uppercase mb-3">What Ships in the Box</p>
+        <h2 class="text-3xl md:text-4xl font-bold text-white">Everything is wired together</h2>
+        <p class="text-gray-400 mt-4 max-w-lg mx-auto">Skills, servers, and integrations keep growing. Here's what's configured today.</p>
+      </div>
+
+      <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-4 fade-in">
+        <div class="card p-5">
+          <div class="icon-box bg-db-orange/10 mb-3">
+            <i data-lucide="zap" class="w-4 h-4 text-db-orange"></i>
+          </div>
+          <h3 class="text-sm font-semibold text-white mb-1.5">Databricks Skills</h3>
+          <p class="text-gray-500 text-xs leading-relaxed">Pipelines, dashboards, Unity Catalog, Lakebase — a growing library.</p>
+        </div>
+
+        <div class="card p-5">
+          <div class="icon-box bg-db-orange/10 mb-3">
+            <i data-lucide="plug" class="w-4 h-4 text-db-orange"></i>
+          </div>
+          <h3 class="text-sm font-semibold text-white mb-1.5">MCP Servers</h3>
+          <p class="text-gray-500 text-xs leading-relaxed">DeepWiki, Exa, and more — wired into every agent and growing.</p>
+        </div>
+
+        <div class="card p-5">
+          <div class="icon-box bg-db-orange/10 mb-3">
+            <i data-lucide="activity" class="w-4 h-4 text-db-orange"></i>
+          </div>
+          <h3 class="text-sm font-semibold text-white mb-1.5">MLflow Tracing</h3>
+          <p class="text-gray-500 text-xs leading-relaxed">Every agent session auto-traced, queryable via Genie.</p>
+        </div>
+
+        <div class="card p-5">
+          <div class="icon-box bg-db-orange/10 mb-3">
+            <i data-lucide="git-branch" class="w-4 h-4 text-db-orange"></i>
+          </div>
+          <h3 class="text-sm font-semibold text-white mb-1.5">Workspace Sync</h3>
+          <p class="text-gray-500 text-xs leading-relaxed"><code class="text-xs">git commit</code> auto-pushes to your Workspace path.</p>
+        </div>
+
+        <div class="card p-5">
+          <div class="icon-box bg-db-orange/10 mb-3">
+            <i data-lucide="settings" class="w-4 h-4 text-db-orange"></i>
+          </div>
+          <h3 class="text-sm font-semibold text-white mb-1.5">AI Gateway Routing</h3>
+          <p class="text-gray-500 text-xs leading-relaxed">One config, any model, full cost tracking.</p>
+        </div>
+
+        <div class="card p-5">
+          <div class="icon-box bg-db-orange/10 mb-3">
+            <i data-lucide="palette" class="w-4 h-4 text-db-orange"></i>
+          </div>
+          <h3 class="text-sm font-semibold text-white mb-1.5">Terminal Themes</h3>
+          <p class="text-gray-500 text-xs leading-relaxed">Dracula, Nord, Monokai, and more. Pick your vibe.</p>
+        </div>
+
+        <div class="card p-5">
+          <div class="icon-box bg-db-orange/10 mb-3">
+            <i data-lucide="mic" class="w-4 h-4 text-db-orange"></i>
+          </div>
+          <h3 class="text-sm font-semibold text-white mb-1.5">Voice & Image Input</h3>
+          <p class="text-gray-500 text-xs leading-relaxed">Dictate or drag-drop images into the terminal.</p>
+        </div>
+
+        <div class="card p-5">
+          <div class="icon-box bg-db-orange/10 mb-3">
+            <i data-lucide="shield" class="w-4 h-4 text-db-orange"></i>
+          </div>
+          <h3 class="text-sm font-semibold text-white mb-1.5">Supply Chain Security</h3>
+          <p class="text-gray-500 text-xs leading-relaxed">All deps SHA-pinned. Weekly CVE audits via GitHub Actions.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ============================================================ -->
+  <!-- PLATFORM (moved down — explain after showing)                 -->
+  <!-- ============================================================ -->
+  <section id="platform" class="relative z-10 py-24 px-4">
+    <div class="max-w-5xl mx-auto">
+      <div class="text-center mb-14 fade-in">
+        <p class="text-db-orange text-xs font-semibold tracking-widest uppercase mb-3">Why Databricks Apps?</p>
+        <h2 class="text-3xl md:text-4xl font-bold text-white">You bring the code.<br>Databricks brings the infra.</h2>
+        <p class="text-gray-400 mt-4 max-w-lg mx-auto">Running coding agents locally means juggling API keys, model access, and governance. Databricks Apps handles all of that.</p>
+      </div>
+
+      <div class="grid md:grid-cols-3 gap-4 mb-8 fade-in">
+        <div class="card p-7">
+          <div class="icon-box bg-db-orange/10 mb-5">
+            <i data-lucide="shield-check" class="w-5 h-5 text-db-orange"></i>
+          </div>
+          <h3 class="text-base font-semibold text-white mb-2">Identity & Auth</h3>
+          <p class="text-gray-400 text-sm leading-relaxed">
+            Your workspace token flows through. No API key juggling. Single-user isolation by default.
+          </p>
+        </div>
+
+        <div class="card p-7">
+          <div class="icon-box bg-db-orange/10 mb-5">
+            <i data-lucide="route" class="w-5 h-5 text-db-orange"></i>
+          </div>
+          <h3 class="text-base font-semibold text-white mb-2">AI Gateway</h3>
+          <p class="text-gray-400 text-sm leading-relaxed">
+            Route agents to any foundation model — Claude, GPT, Gemini — through one gateway. Usage tracked, costs governed.
+          </p>
+        </div>
+
+        <div class="card p-7">
+          <div class="icon-box bg-db-orange/10 mb-5">
+            <i data-lucide="database" class="w-5 h-5 text-db-orange"></i>
+          </div>
+          <h3 class="text-base font-semibold text-white mb-2">Data & Governance</h3>
+          <p class="text-gray-400 text-sm leading-relaxed">
+            Unity Catalog, MLflow, Workspace files — agents have native access to your entire lakehouse.
+          </p>
+        </div>
+      </div>
+
+      <div class="card p-6 text-center fade-in">
+        <p class="text-gray-400 text-sm">
+          Databricks Apps gives coding agents what they actually need: <span class="text-white font-medium">identity, models, data, and governance</span>. CoDA just wires it all together.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ============================================================ -->
+  <!-- GENIE CODE                                                    -->
+  <!-- ============================================================ -->
+  <section id="genie-code" class="relative z-10 py-24 px-4">
+    <div class="max-w-3xl mx-auto">
+      <div class="card p-8 md:p-10 fade-in">
+        <div class="flex flex-col md:flex-row items-start gap-6">
+          <div class="icon-box bg-db-orange/10 flex-shrink-0" style="width:48px;height:48px;">
+            <i data-lucide="wand-2" class="w-5 h-5 text-db-orange"></i>
+          </div>
+          <div>
+            <p class="text-db-orange text-xs font-semibold tracking-widest uppercase mb-2">Need something more specialized?</p>
+            <h2 class="text-xl md:text-2xl font-bold text-white mb-3">CoDA agents are general-purpose. Genie Code is bespoke.</h2>
+            <p class="text-gray-400 text-sm leading-relaxed mb-4">
+              The agents in CoDA — Claude Code, Codex, Gemini CLI, OpenCode — are general-purpose coding agents that work across any codebase. They're great for broad software engineering tasks.
+            </p>
+            <p class="text-gray-400 text-sm leading-relaxed mb-6">
+              But if you need an agent that deeply understands your lakehouse — your table schemas, column lineage, governance policies, pipeline failures — <span class="text-white font-medium">Genie Code</span> is purpose-built for that. It's Databricks' autonomous AI agent for data engineering, data science, and ML work, with native Unity Catalog context that general-purpose agents can't match.
+            </p>
+            <a href="https://www.databricks.com/blog/introducing-genie-code" target="_blank"
+               class="text-db-orange hover:text-db-light transition-colors text-sm font-medium inline-flex items-center gap-1.5">
+              Read the Genie Code announcement <i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ============================================================ -->
+  <!-- DEPLOY                                                        -->
+  <!-- ============================================================ -->
+  <section id="deploy" class="relative z-10 py-24 px-4">
+    <div class="max-w-3xl mx-auto">
+      <div class="text-center mb-14 fade-in">
+        <p class="text-db-orange text-xs font-semibold tracking-widest uppercase mb-3">Get Started</p>
+        <h2 class="text-3xl md:text-4xl font-bold text-white">Three steps. No Terraform.</h2>
+      </div>
+
+      <div class="space-y-4 mb-12">
+        <div class="card p-6 flex flex-col sm:flex-row items-start gap-5 fade-in">
+          <div class="step-number">1</div>
+          <div>
+            <h3 class="text-base font-semibold text-white mb-1">Fork the template</h3>
+            <p class="text-gray-400 text-sm">One click on GitHub. You get the full CoDA setup — agents, skills, MCP servers, themes, and CI.</p>
+          </div>
+        </div>
+
+        <div class="card p-6 flex flex-col sm:flex-row items-start gap-5 fade-in">
+          <div class="step-number">2</div>
+          <div>
+            <h3 class="text-base font-semibold text-white mb-1">Create a Databricks App</h3>
+            <p class="text-gray-400 text-sm">Connect your repo, pick a name. Databricks handles compute, networking, and identity.</p>
+          </div>
+        </div>
+
+        <div class="card p-6 flex flex-col sm:flex-row items-start gap-5 fade-in">
+          <div class="step-number">3</div>
+          <div>
+            <h3 class="text-base font-semibold text-white mb-1">Set your token, deploy</h3>
+            <p class="text-gray-400 text-sm">Add your Databricks token as a secret, hit deploy. Agents start with the app.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="text-center fade-in">
+        <div class="flex flex-wrap justify-center gap-2 mb-8">
+          <span class="px-3 py-1.5 rounded-lg bg-surface-1 border border-white/5 text-gray-500 text-xs line-through">Dockerfile</span>
+          <span class="px-3 py-1.5 rounded-lg bg-surface-1 border border-white/5 text-gray-500 text-xs line-through">Terraform</span>
+          <span class="px-3 py-1.5 rounded-lg bg-surface-1 border border-white/5 text-gray-500 text-xs line-through">Kubernetes</span>
+          <span class="px-3 py-1.5 rounded-lg bg-db-orange/10 border border-db-orange/20 text-db-orange text-xs font-semibold">app.yaml</span>
+        </div>
+        <a href="https://github.com/datasciencemonkey/coding-agents-databricks-apps" target="_blank"
+           class="cta-primary px-7 py-3.5 rounded-xl text-white font-semibold text-sm inline-flex items-center gap-2">
+          <i data-lucide="github" class="w-4 h-4"></i> Fork on GitHub
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- ============================================================ -->
+  <!-- FOOTER                                                        -->
+  <!-- ============================================================ -->
+  <footer class="relative z-10 py-16 px-4">
+    <div class="max-w-5xl mx-auto text-center">
+      <p class="text-xl font-bold gradient-text mb-2">CoDA</p>
+      <p class="text-gray-500 text-sm mb-8">Co-Working Developer Agents — built for the Databricks Lakehouse</p>
+
+      <div class="flex flex-wrap justify-center gap-6 mb-8">
+        <a href="https://github.com/datasciencemonkey/coding-agents-databricks-apps" target="_blank"
+           class="text-gray-400 hover:text-white transition-colors inline-flex items-center gap-1.5 text-sm">
+          <i data-lucide="github" class="w-4 h-4"></i> Repo
+        </a>
+        <a href="https://github.com/datasciencemonkey/coding-agents-databricks-apps/blob/main/docs/deployment.md" target="_blank"
+           class="text-gray-400 hover:text-white transition-colors inline-flex items-center gap-1.5 text-sm">
+          <i data-lucide="book-open" class="w-4 h-4"></i> Deploy Guide
+        </a>
+        <a href="https://github.com/datasciencemonkey/coding-agents-databricks-apps#readme" target="_blank"
+           class="text-gray-400 hover:text-white transition-colors inline-flex items-center gap-1.5 text-sm">
+          <i data-lucide="file-text" class="w-4 h-4"></i> README
+        </a>
+      </div>
+
+      <div class="flex justify-center items-center gap-3 mb-6">
+        <span class="text-xs text-gray-600 px-2.5 py-1 rounded-md border border-white/5 bg-surface-1">v0.16.4</span>
+      </div>
+
+      <p class="text-xs text-gray-600">
+        Built by <span class="text-gray-400">Databricks Field Engineering</span>
+      </p>
+    </div>
+  </footer>
+
+  <!-- ============================================================ -->
+  <!-- JAVASCRIPT                                                    -->
+  <!-- ============================================================ -->
+  <script>
+    lucide.createIcons();
+
+    // ---- Reduced motion check ----
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    // ---- Navbar scroll ----
+    window.addEventListener('scroll', () => {
+      document.getElementById('navbar').classList.toggle('scrolled', window.scrollY > 50);
+    });
+
+    // ---- Mobile menu ----
+    document.getElementById('mobile-menu-btn').addEventListener('click', () => {
+      const menu = document.getElementById('mobile-menu');
+      menu.classList.toggle('hidden');
+    });
+    // Close mobile menu on link click
+    document.querySelectorAll('#mobile-menu a').forEach(a => {
+      a.addEventListener('click', () => {
+        document.getElementById('mobile-menu').classList.add('hidden');
+      });
+    });
+
+    // ---- Scroll fade-in ----
+    if (!prefersReducedMotion) {
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) entry.target.classList.add('visible');
+        });
+      }, { threshold: 0.08 });
+      document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+    } else {
+      // Show everything immediately
+      document.querySelectorAll('.fade-in').forEach(el => el.classList.add('visible'));
+    }
+
+    // ---- Terminal typewriter ----
+    const terminalLines = {
+      claude: [
+        '<span class="text-gray-600">$</span> <span class="text-amber-400">claude</span> <span class="text-gray-300">"Add an API endpoint for user preferences"</span>',
+        '<span class="text-gray-500">Reading codebase... found 12 relevant files</span>',
+        '<span class="text-green-400">&#10003;</span> Created <span class="text-blue-300">src/api/preferences.py</span> with CRUD endpoints',
+        '<span class="text-green-400">&#10003;</span> Added Unity Catalog integration for preference storage',
+        '<span class="text-green-400">&#10003;</span> Tests passing (8/8). Ready for review.',
+      ],
+      codex: [
+        '<span class="text-gray-600">$</span> <span class="text-emerald-400">codex</span> <span class="text-gray-300">"Refactor the data pipeline to use streaming"</span>',
+        '<span class="text-gray-500">Analyzing pipeline architecture...</span>',
+        '<span class="text-green-400">&#10003;</span> Converted batch ETL to Structured Streaming',
+        '<span class="text-green-400">&#10003;</span> Added checkpointing and exactly-once guarantees',
+        '<span class="text-green-400">&#10003;</span> Pipeline throughput improved 3.2x',
+      ],
+      gemini: [
+        '<span class="text-gray-600">$</span> <span class="text-blue-400">gemini</span> <span class="text-gray-300">"Analyze this architecture diagram and implement it"</span>',
+        '<span class="text-gray-500">Processing image... identified 6 components</span>',
+        '<span class="text-green-400">&#10003;</span> Generated configs for each service',
+        '<span class="text-green-400">&#10003;</span> Created integration tests with Databricks Connect',
+        '<span class="text-green-400">&#10003;</span> All services deployed and health-checked',
+      ],
+      opencode: [
+        '<span class="text-gray-600">$</span> <span class="text-purple-400">opencode</span> <span class="text-gray-300">"Debug the failing MLflow experiment"</span>',
+        '<span class="text-gray-500">Tracing experiment run #847...</span>',
+        '<span class="text-yellow-400">!</span> Found: feature drift in column <span class="text-red-300">"user_segment"</span>',
+        '<span class="text-green-400">&#10003;</span> Added data validation step',
+        '<span class="text-green-400">&#10003;</span> Experiment #848 passing — metrics within threshold',
+      ],
+    };
+
+    let currentAgent = 'claude';
+    let lineIndex = 0;
+    let typewriterTimeout = null;
+    let lineTimeout = null;
+    const outputEl = document.getElementById('terminal-output');
+
+    function stripHtml(html) {
+      return html.replace(/<[^>]*>/g, '');
+    }
+
+    function typeNextLine() {
+      const lines = terminalLines[currentAgent];
+      if (lineIndex >= lines.length) {
+        lineTimeout = setTimeout(() => {
+          const agents = Object.keys(terminalLines);
+          const nextIdx = (agents.indexOf(currentAgent) + 1) % agents.length;
+          switchAgent(agents[nextIdx]);
+        }, 2500);
+        return;
+      }
+
+      const fullHtml = lines[lineIndex];
+      const plainText = stripHtml(fullHtml);
+      const lineEl = document.createElement('div');
+      lineEl.className = 'mb-1';
+      outputEl.appendChild(lineEl);
+      let charIndex = 0;
+
+      if (prefersReducedMotion) {
+        lineEl.innerHTML = fullHtml;
+        lineIndex++;
+        lineTimeout = setTimeout(typeNextLine, 150);
+        return;
+      }
+
+      function typeChar() {
+        if (charIndex <= plainText.length) {
+          if (charIndex === plainText.length) {
+            lineEl.innerHTML = fullHtml;
+          } else {
+            lineEl.textContent = plainText.substring(0, charIndex);
+          }
+          charIndex++;
+          typewriterTimeout = setTimeout(typeChar, 18 + Math.random() * 12);
+        } else {
+          lineIndex++;
+          lineTimeout = setTimeout(typeNextLine, 250);
+        }
+      }
+      typeChar();
+    }
+
+    function switchAgent(agent) {
+      clearTimeout(typewriterTimeout);
+      clearTimeout(lineTimeout);
+      currentAgent = agent;
+      lineIndex = 0;
+      outputEl.innerHTML = '';
+
+      document.querySelectorAll('.terminal-tab').forEach(tab => {
+        const isActive = tab.dataset.agent === agent;
+        tab.classList.toggle('active', isActive);
+        tab.setAttribute('aria-selected', isActive);
+      });
+
+      typeNextLine();
+    }
+
+    document.querySelectorAll('.terminal-tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        if (tab.dataset.agent !== currentAgent) switchAgent(tab.dataset.agent);
+      });
+      tab.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          if (tab.dataset.agent !== currentAgent) switchAgent(tab.dataset.agent);
+        }
+      });
+    });
+
+    typeNextLine();
+
+    // ---- Smooth scroll for anchor links ----
+    document.querySelectorAll('a[href^="#"]').forEach(a => {
+      a.addEventListener('click', (e) => {
+        e.preventDefault();
+        const target = document.querySelector(a.getAttribute('href'));
+        if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        // Close mobile menu if open
+        document.getElementById('mobile-menu').classList.add('hidden');
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a static landing page at `docs/site/index.html`
- Served via GitHub Pages at `datasciencemonkey.github.io/coding-agents-databricks-apps/site/`
- Single self-contained HTML file — zero build step

## Sections
- **Hero** — Terminal mockup with typewriter cycling through 4 agents
- **Agents** — Claude Code, Codex, Gemini CLI, OpenCode
- **Features** — Skills, MCP Servers, MLflow Tracing, Workspace Sync, etc.
- **Platform** — Why Databricks Apps (Identity, AI Gateway, Governance)
- **Genie Code** — Callout for bespoke specialist agents → [blog post](https://www.databricks.com/blog/introducing-genie-code)
- **Deploy** — Three-step guide

## Design decisions
- No glassmorphism, no particle effects, no animation overload — reviewed by 4 specialist agents for "AI slop" and cleaned up
- Solid surface elevation system, unified brand orange palette, developer-native copy
- `prefers-reduced-motion` support, keyboard accessible terminal tabs, mobile hamburger menu
- Pinned Lucide `0.344.0` (not `@latest`)

## To enable GitHub Pages after merge
1. Go to **Settings → Pages**
2. Source: **Deploy from a branch**
3. Branch: **main**, Folder: **/docs**
4. Save — page goes live at the URL above

Closes #66

This pull request was AI-assisted by Isaac.