### PR TITLE
fix: add model tier mappings and disable experimental betas

### DIFF
--- a/app.py
+++ b/app.py
@@ -288,10 +288,14 @@ def _configure_all_cli_auth(token):
 
     settings = {
         "env": {
-            "ANTHROPIC_MODEL": os.environ.get("ANTHROPIC_MODEL", "databricks-claude-sonnet-4-6"),
+            "ANTHROPIC_MODEL": os.environ.get("ANTHROPIC_MODEL", "databricks-claude-opus-4-6"),
             "ANTHROPIC_BASE_URL": anthropic_base_url,
             "ANTHROPIC_AUTH_TOKEN": token,
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "databricks-claude-opus-4-6",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": "databricks-claude-sonnet-4-6",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "databricks-claude-haiku-4-5",
             "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true",
+            "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
         }
     }
 

--- a/setup_claude.py
+++ b/setup_claude.py
@@ -32,10 +32,14 @@ if token:
 
     settings = {
         "env": {
-            "ANTHROPIC_MODEL": os.environ.get("ANTHROPIC_MODEL", "databricks-claude-sonnet-4-6"),
+            "ANTHROPIC_MODEL": os.environ.get("ANTHROPIC_MODEL", "databricks-claude-opus-4-6"),
             "ANTHROPIC_BASE_URL": anthropic_base_url,
             "ANTHROPIC_AUTH_TOKEN": token,
-            "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true"
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "databricks-claude-opus-4-6",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": "databricks-claude-sonnet-4-6",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "databricks-claude-haiku-4-5",
+            "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true",
+            "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL` to Claude settings so model tier switching works correctly through the Databricks AI Gateway
- Adds `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` to prevent 400 errors from the gateway rejecting experimental `cache_control.scope` fields
- Updates default `ANTHROPIC_MODEL` from `databricks-claude-sonnet-4-6` to `databricks-claude-opus-4-6`

## Context
Newer Claude Code versions send `cache_control: { type: "ephemeral", scope: "..." }` on system messages as an experimental beta feature. The Databricks AI Gateway proxy uses strict validation and rejects the unknown `scope` field with:
```
API Error: 400 {"message":"system.2.cache_control.ephemeral.scope: Extra inputs are not permitted"}
```

## Files changed
- `app.py` — runtime settings written during token rotation
- `setup_claude.py` — initial settings written at app startup

## Test plan
- [ ] Deploy to a Databricks workspace and verify Claude Code starts without the 400 error
- [ ] Verify model tier switching works (e.g. subagent spawning with haiku/sonnet)

This pull request was AI-assisted by Isaac.