### PR TITLE
feat: integrate Hermes Agent as 5th coding CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude Code on Databricks
 
-Welcome! This environment comes pre-configured with 39 skills and 2 MCP servers.
+Welcome! This environment comes pre-configured with 5 AI coding agents, 39 skills, and 2 MCP servers. Hermes Agent is available alongside Claude Code, Codex, Gemini CLI, and OpenCode — launch it with `hermes chat`.
 
 ## Skills (30 total)
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Use this template](https://img.shields.io/badge/Use%20this%20template-2ea44f?logo=github)](https://github.com/datasciencemonkey/coding-agents-databricks-apps/generate)
 [![Deploy to Databricks](https://img.shields.io/badge/Deploy-Databricks%20Apps-FF3621?logo=databricks&logoColor=white)](docs/deployment.md)
-[![Agents](https://img.shields.io/badge/Agents-4%20included-green)](#whats-inside)
+[![Agents](https://img.shields.io/badge/Agents-5%20included-green)](#whats-inside)
 [![Skills](https://img.shields.io/badge/Skills-39%20built--in-blue)](#-all-39-skills)
 
-> Run Claude Code, Codex, Gemini CLI, and OpenCode in your browser — zero setup, wired to your Databricks workspace.
+> Run Claude Code, Codex, Gemini CLI, Hermes Agent, and OpenCode in your browser — zero setup, wired to your Databricks workspace.
 
 ---
 
@@ -24,6 +24,8 @@
 🟣 **Codex** — OpenAI's coding agent, pre-configured for Databricks
 
 🔵 **Gemini CLI** — Google's coding agent with shared skills
+
+🟡 **Hermes Agent** — NousResearch's multi-provider AI CLI with tool-calling and skills
 
 🟢 **OpenCode** — Open-source agent with multi-provider support
 
@@ -55,7 +57,7 @@ This isn't just a terminal in the cloud. Running coding agents on Databricks giv
 | ✂️ **Split Panes** | Run two sessions side by side with a draggable divider |
 | 🌐 **WebSocket I/O** | Real-time terminal output over WebSocket — zero-latency, eliminates polling delay |
 | 🔁 **HTTP Polling Fallback** | Automatic fallback via Web Worker when WebSocket is unavailable |
-| 🚀 **Parallel Setup** | 6 agent setups run in parallel (~5x faster startup) |
+| 🚀 **Parallel Setup** | 7 agent setups run in parallel (~5x faster startup) |
 | 🔍 **Search** | Find anything in your terminal history (Ctrl+Shift+F) |
 | 🎤 **Voice Input** | Dictate commands with your mic (Option+V) |
 | 📋 **Image Paste** | Paste or drag-and-drop images into the terminal — saved to `~/uploads/`, path inserted automatically |

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ This template repo opens that vision up for every Databricks user — no IDE set
 | `HOME` | Yes | Set to `/app/python/source_code` in app.yaml |
 | `ANTHROPIC_MODEL` | No | Claude model name (default: `databricks-claude-opus-4-6`) |
 | `CODEX_MODEL` | No | Codex model name (default: `databricks-gpt-5-3-codex`) |
-| `GEMINI_MODEL` | No | Gemini model name (default: `databricks-gemini-3-1-pro`) |
+| `GEMINI_MODEL` | No | Gemini model name (default: `databricks-gemini-2-5-pro`) |
 | `DATABRICKS_GATEWAY_HOST` | No | AI Gateway URL override. Auto-discovered from `DATABRICKS_WORKSPACE_ID` if unset |
 
 ### Security Model

--- a/app.py
+++ b/app.py
@@ -110,6 +110,7 @@ setup_state = {
         {"id": "codex",      "label": "Configuring Codex CLI",        "status": "pending", "started_at": None, "completed_at": None, "error": None},
         {"id": "opencode",   "label": "Configuring OpenCode CLI",     "status": "pending", "started_at": None, "completed_at": None, "error": None},
         {"id": "gemini",     "label": "Configuring Gemini CLI",       "status": "pending", "started_at": None, "completed_at": None, "error": None},
+        {"id": "hermes",     "label": "Configuring Hermes Agent",     "status": "pending", "started_at": None, "completed_at": None, "error": None},
         {"id": "databricks", "label": "Setting up Databricks CLI",    "status": "pending", "started_at": None, "completed_at": None, "error": None},
         {"id": "mlflow",     "label": "Enabling MLflow tracing",       "status": "pending", "started_at": None, "completed_at": None, "error": None},
     ]
@@ -317,7 +318,7 @@ def _configure_all_cli_auth(token):
     # 3. Re-run Codex, OpenCode, Gemini setup scripts with token in env
     #    They are idempotent: detect CLI already installed, just write config files
     env = {**os.environ, "DATABRICKS_TOKEN": token}
-    for script in ["setup_codex.py", "setup_opencode.py", "setup_gemini.py"]:
+    for script in ["setup_codex.py", "setup_opencode.py", "setup_gemini.py", "setup_hermes.py"]:
         try:
             result = subprocess.run(
                 ["uv", "run", "python", script],
@@ -368,6 +369,7 @@ def run_setup():
         ("codex",      ["uv", "run", "python", "setup_codex.py"]),
         ("opencode",   ["uv", "run", "python", "setup_opencode.py"]),
         ("gemini",     ["uv", "run", "python", "setup_gemini.py"]),
+        ("hermes",     ["uv", "run", "python", "setup_hermes.py"]),
         ("databricks", ["uv", "run", "python", "setup_databricks.py"]),
         ("mlflow",     ["uv", "run", "python", "setup_mlflow.py"]),
     ]

--- a/app.py
+++ b/app.py
@@ -381,6 +381,18 @@ def run_setup():
         ]
         wait(futures)
 
+    # Sync latest token into all CLI configs — covers the race where PAT
+    # rotation happened while a setup script was still installing (the
+    # rotation's update_cli_tokens() call silently skips missing config files).
+    current_token = os.environ.get("DATABRICKS_TOKEN", "")
+    if current_token:
+        try:
+            from cli_auth import update_cli_tokens
+            update_cli_tokens(current_token)
+            logger.info("Post-setup token sync: all CLI configs updated with current token")
+        except Exception as e:
+            logger.warning(f"Post-setup token sync failed: {e}")
+
     with setup_lock:
         any_error = any(s["status"] == "error" for s in setup_state["steps"])
         setup_state["status"] = "error" if any_error else "complete"

--- a/app.py
+++ b/app.py
@@ -1009,6 +1009,9 @@ def create_session():
         # DATABRICKS_HOST is set in env (even without credentials).
         shell_env.pop("DATABRICKS_TOKEN", None)
         shell_env.pop("DATABRICKS_HOST", None)
+        # Also strip CLI-specific API keys so they read from config files
+        # (always current after rotation) instead of stale env snapshots.
+        shell_env.pop("GEMINI_API_KEY", None)
         # Ensure HOME is set correctly
         if not shell_env.get("HOME") or shell_env["HOME"] == "/":
             shell_env["HOME"] = "/app/python/source_code"

--- a/app.yaml
+++ b/app.yaml
@@ -7,7 +7,7 @@ env:
   - name: ANTHROPIC_MODEL
     value: databricks-claude-opus-4-7
   - name: GEMINI_MODEL
-    value: databricks-gemini-3-1-pro
+    value: databricks-gemini-2-5-pro
   - name: CODEX_MODEL
     value: databricks-gpt-5-3-codex
   - name: CLAUDE_CODE_DISABLE_AUTO_MEMORY

--- a/app.yaml.template
+++ b/app.yaml.template
@@ -10,6 +10,14 @@ env:
     value: databricks-claude-opus-4-6
   - name: GEMINI_MODEL
     value: databricks-gemini-3-1-pro
+  - name: HERMES_MODEL
+    value: databricks-claude-opus-4-7
+  - name: HERMES_FALLBACK_MODEL
+    value: databricks-claude-opus-4-6
+  # Set ENABLE_HERMES=false to skip Hermes Agent install (saves ~180 MB / ~90 s
+  # at container start). Other CLIs are unaffected.
+  - name: ENABLE_HERMES
+    value: "true"
   #OPTIONAL: Use the new Databricks AI Gateway if you have access (recommended), otherwise it will default to the older endpoint
   - name: DATABRICKS_GATEWAY_HOST
     value: https://<your-gateway-id>.ai-gateway.<env>.cloud.databricks.com

--- a/app.yaml.template
+++ b/app.yaml.template
@@ -14,8 +14,8 @@ env:
     value: databricks-claude-opus-4-7
   - name: HERMES_FALLBACK_MODEL
     value: databricks-claude-opus-4-6
-  # Set ENABLE_HERMES=false to skip Hermes Agent install (saves ~180 MB / ~90 s
-  # at container start). Other CLIs are unaffected.
+  # Set ENABLE_HERMES=false to skip Hermes Agent install.
+  # Other CLIs are unaffected.
   - name: ENABLE_HERMES
     value: "true"
   #OPTIONAL: Use the new Databricks AI Gateway if you have access (recommended), otherwise it will default to the older endpoint

--- a/app.yaml.template
+++ b/app.yaml.template
@@ -9,7 +9,7 @@ env:
   - name: ANTHROPIC_MODEL
     value: databricks-claude-opus-4-6
   - name: GEMINI_MODEL
-    value: databricks-gemini-3-1-pro
+    value: databricks-gemini-2-5-pro
   - name: HERMES_MODEL
     value: databricks-claude-opus-4-7
   - name: HERMES_FALLBACK_MODEL

--- a/cli_auth.py
+++ b/cli_auth.py
@@ -22,6 +22,7 @@ def update_cli_tokens(token):
     _update_codex(token)
     _update_opencode(token)
     _update_gemini(token)
+    _update_hermes(token)
 
 
 def _update_claude(token):
@@ -66,6 +67,25 @@ def _update_gemini(token):
     """Update GEMINI_API_KEY in ~/.gemini/.env."""
     path = os.path.join(_HOME, ".gemini", ".env")
     _replace_dotenv_key(path, "GEMINI_API_KEY", token)
+
+
+def _update_hermes(token):
+    """Update api_key lines in ~/.hermes/config.yaml."""
+    path = os.path.join(_HOME, ".hermes", "config.yaml")
+    try:
+        with open(path) as f:
+            content = f.read()
+        new_content = re.sub(
+            r'^(  api_key: ).*$',
+            rf'\g<1>{token}',
+            content,
+            flags=re.MULTILINE
+        )
+        if new_content != content:
+            with open(path, "w") as f:
+                f.write(new_content)
+    except OSError:
+        pass
 
 
 def _replace_dotenv_key(path, key, value):

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,6 +70,7 @@ databricks apps deploy <your-app-name> \
 | `ANTHROPIC_MODEL` | No | Claude model name (default: `databricks-claude-opus-4-6`) |
 | `CODEX_MODEL` | No | Codex model name (default: `databricks-gpt-5-3-codex`) |
 | `GEMINI_MODEL` | No | Gemini model name (default: `databricks-gemini-3-1-pro`) |
+| `HERMES_MODEL` | No | Hermes model name (default: `databricks-claude-opus-4-7`) |
 | `DATABRICKS_GATEWAY_HOST` | No | AI Gateway URL override. Auto-discovered from `DATABRICKS_WORKSPACE_ID` if unset. Falls back to direct model serving if neither is available |
 
 ## Security Model
@@ -78,7 +79,7 @@ This is a **single-user, zero-config auth** app. No secrets or tokens are requir
 
 1. **Owner resolution**: The app owner is determined from `app.creator` via the service principal + Apps API — no PAT needed
 2. **Authorization**: Each request's `X-Forwarded-Email` header is compared against `app.creator`. Non-matching users see 403
-3. **Interactive PAT setup**: On first terminal session, the user pastes a short-lived PAT interactively. All CLIs (Claude, Codex, OpenCode, Gemini, Databricks) are configured automatically
+3. **Interactive PAT setup**: On first terminal session, the user pastes a short-lived PAT interactively. All CLIs (Claude, Codex, OpenCode, Gemini, Hermes, Databricks) are configured automatically
 4. **Auto-rotation**: PAT rotates every 10 minutes with a 15-minute lifetime. Old tokens are proactively revoked. Maximum leaked-token exposure: 15 minutes
 5. **Session-aware**: Rotation is skipped when no active terminal sessions exist
 6. **On restart**: The user re-pastes a token (no persistence by design)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -69,7 +69,7 @@ databricks apps deploy <your-app-name> \
 | `HOME` | Yes | Set to `/app/python/source_code` in app.yaml |
 | `ANTHROPIC_MODEL` | No | Claude model name (default: `databricks-claude-opus-4-6`) |
 | `CODEX_MODEL` | No | Codex model name (default: `databricks-gpt-5-3-codex`) |
-| `GEMINI_MODEL` | No | Gemini model name (default: `databricks-gemini-3-1-pro`) |
+| `GEMINI_MODEL` | No | Gemini model name (default: `databricks-gemini-2-5-pro`) |
 | `HERMES_MODEL` | No | Hermes model name (default: `databricks-claude-opus-4-7`) |
 | `DATABRICKS_GATEWAY_HOST` | No | AI Gateway URL override. Auto-discovered from `DATABRICKS_WORKSPACE_ID` if unset. Falls back to direct model serving if neither is available |
 

--- a/setup_gemini.py
+++ b/setup_gemini.py
@@ -88,12 +88,12 @@ try:
         trusted = json.loads(trusted_folders_path.read_text())
     else:
         trusted = {}
-    if projects_dir not in trusted:
-        trusted[projects_dir] = True
+    if trusted.get(projects_dir) != "TRUST_FOLDER":
+        trusted[projects_dir] = "TRUST_FOLDER"
     # Also trust home dir so ~/.gemini/.env is always loadable
     home_str = str(home)
-    if home_str not in trusted:
-        trusted[home_str] = True
+    if trusted.get(home_str) != "TRUST_FOLDER":
+        trusted[home_str] = "TRUST_FOLDER"
     trusted_folders_path.write_text(json.dumps(trusted, indent=2))
     print(f"Gemini trusted folders configured: {trusted_folders_path}")
 except Exception as e:

--- a/setup_gemini.py
+++ b/setup_gemini.py
@@ -78,6 +78,27 @@ else:
 gemini_dir = home / ".gemini"
 gemini_dir.mkdir(exist_ok=True)
 
+# Pre-trust ~/projects/ so Gemini CLI loads .env and project settings.
+# Without this, Gemini's security engine silently skips .env loading in
+# untrusted workspaces, causing auth failures (see gemini-cli#20005).
+projects_dir = str(home / "projects")
+trusted_folders_path = gemini_dir / "trustedFolders.json"
+try:
+    if trusted_folders_path.exists():
+        trusted = json.loads(trusted_folders_path.read_text())
+    else:
+        trusted = {}
+    if projects_dir not in trusted:
+        trusted[projects_dir] = True
+    # Also trust home dir so ~/.gemini/.env is always loadable
+    home_str = str(home)
+    if home_str not in trusted:
+        trusted[home_str] = True
+    trusted_folders_path.write_text(json.dumps(trusted, indent=2))
+    print(f"Gemini trusted folders configured: {trusted_folders_path}")
+except Exception as e:
+    print(f"Warning: could not write trustedFolders.json: {e}")
+
 # Write .env file with Databricks endpoint configuration
 # Gemini CLI auto-loads env from ~/.gemini/.env
 # The Google-native endpoint on Databricks mirrors /serving-endpoints/anthropic

--- a/setup_gemini.py
+++ b/setup_gemini.py
@@ -26,7 +26,7 @@ home = Path(os.environ["HOME"])
 
 host = os.environ.get("DATABRICKS_HOST", "")
 token = os.environ.get("DATABRICKS_TOKEN", "")
-gemini_model = os.environ.get("GEMINI_MODEL", "databricks-gemini-3-1-pro")
+gemini_model = os.environ.get("GEMINI_MODEL", "databricks-gemini-2-5-pro")
 
 # 1. Install Gemini CLI into ~/.local/bin (always, even without token)
 local_bin = home / ".local" / "bin"

--- a/setup_gemini.py
+++ b/setup_gemini.py
@@ -84,7 +84,7 @@ gemini_dir.mkdir(exist_ok=True)
 env_content = f"""# Databricks Model Serving - Google Gemini native endpoint
 GEMINI_MODEL={gemini_model}
 GOOGLE_GEMINI_BASE_URL={gemini_base_url}
-GEMINI_API_KEY_AUTH_MECHANISM="bearer"
+GEMINI_API_KEY_AUTH_MECHANISM=bearer
 GEMINI_API_KEY={auth_token}
 """
 

--- a/setup_hermes.py
+++ b/setup_hermes.py
@@ -5,19 +5,11 @@ Hermes Agent (github.com/NousResearch/hermes-agent) is a multi-provider AI CLI
 with tool-calling, persistent memory, slash commands, and a rich skill system.
 
 Unlike the other CLIs in CoDA, Hermes is a Python application (not npm).
-This script performs a LEAN install (bypassing the upstream installer's
-`.[all]` extras, which pull ~500 MB / 90+ packages) by cloning the repo
-and installing only the extras CoDA actually needs:
+This script installs from PyPI with minimal deps (core covers chat +
+Databricks model serving). The upstream `.[all]` extras pull ~500 MB /
+90+ packages — users can add specific extras later if needed:
 
-    [mcp, messaging, matrix, web, acp]    # ~180 MB, ~90 s on Databricks Apps
-
-This covers Hermes's three CoDA-required capabilities:
-  1. Self-improvement via MCP (deepwiki, exa)
-  2. Pre-wired Databricks Model Serving (core dep — no extra needed)
-  3. Open path for messaging (WhatsApp / Slack / Teams / Matrix / Discord)
-
-Users can add more later via `uv pip install -e ".[voice,rl,feishu,...]"`
-inside ~/.hermes/hermes-agent, or via `hermes setup` / `hermes mcp add`.
+    uv pip install "hermes-agent[mcp,messaging,...]"
 
 Config: ~/.hermes/config.yaml with custom provider for Databricks.
 Auth:   Bearer token via Databricks PAT.
@@ -52,16 +44,12 @@ hermes_model = os.environ.get("HERMES_MODEL", "databricks-claude-opus-4-7")
 hermes_fallback_model = os.environ.get("HERMES_FALLBACK_MODEL", "databricks-claude-opus-4-6")
 
 hermes_home = home / ".hermes"
-hermes_install_dir = hermes_home / "hermes-agent"
-hermes_venv = hermes_install_dir / "venv"
-hermes_venv_bin = hermes_venv / "bin" / "hermes"
 hermes_bin = home / ".local" / "bin" / "hermes"
 
-# Lean extras — covers MCP (self-improvement), messaging paths (WhatsApp/Slack/
-# Teams via matrix bridges), and ACP (agent-to-agent protocol). Excludes voice,
-# rl, feishu, dingtalk, bedrock, mistral, modal, daytona — users opt in later.
-HERMES_EXTRAS = "mcp,messaging,matrix,web,acp"
-HERMES_REPO = "https://github.com/NousResearch/hermes-agent.git"
+# Minimal install from git — core deps (openai, anthropic, prompt_toolkit, rich,
+# httpx, pyyaml, pydantic) cover chat + Databricks model serving. Not on PyPI,
+# so we install directly from GitHub. uv tool install handles venv + binary.
+HERMES_PKG = "hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git"
 
 # 1. Install Hermes Agent (always, even without token).
 local_bin = home / ".local" / "bin"
@@ -75,74 +63,30 @@ def _run(cmd, **kwargs):
     return result.returncode, result.stdout, result.stderr
 
 
-if not hermes_bin.exists() or not hermes_venv_bin.exists():
-    print(f"Installing Hermes Agent (lean extras: [{HERMES_EXTRAS}])...")
+if not hermes_bin.exists():
+    print("Installing Hermes Agent from PyPI (minimal)...")
 
-    # 1a. Clone (or update) the repo.
-    if not hermes_install_dir.exists():
-        rc, _, err = _run(
-            ["git", "clone", "--depth", "1", HERMES_REPO, str(hermes_install_dir)],
-            timeout=180,
-        )
-        if rc != 0:
-            print(f"Hermes git clone failed (rc={rc}): {err[-600:]}")
-            raise SystemExit(0)  # soft-fail — don't crash app startup
-    else:
-        # Best-effort pull; ignore failures (detached HEAD, local edits, etc.)
-        _run(["git", "-C", str(hermes_install_dir), "pull", "--ff-only"], timeout=60)
-
-    # 1b. Create venv with uv.
-    if not hermes_venv.exists():
-        rc, _, err = _run(
-            ["uv", "venv", str(hermes_venv)],
-            timeout=120,
-        )
-        if rc != 0:
-            print(f"Hermes venv create failed (rc={rc}): {err[-600:]}")
-            raise SystemExit(0)
-
-    # 1c. Install with lean extras using uv (fast + respects pyproject extras).
-    install_env = {
-        **os.environ,
-        "VIRTUAL_ENV": str(hermes_venv),
-        "PATH": f"{hermes_venv / 'bin'}:{os.environ.get('PATH', '')}",
-    }
     rc, _, err = _run(
-        ["uv", "pip", "install", "-e", f".[{HERMES_EXTRAS}]"],
-        cwd=str(hermes_install_dir),
-        env=install_env,
+        ["uv", "tool", "install", HERMES_PKG],
         timeout=600,
     )
     if rc != 0:
-        # Fall back to bare install so `hermes` at least launches.
-        print(f"Hermes lean install failed (rc={rc}), falling back to base: {err[-400:]}")
-        rc, _, err = _run(
-            ["uv", "pip", "install", "-e", "."],
-            cwd=str(hermes_install_dir),
-            env=install_env,
-            timeout=600,
-        )
-        if rc != 0:
-            print(f"Hermes base install also failed (rc={rc}): {err[-600:]}")
-            raise SystemExit(0)
+        print(f"Hermes install failed (rc={rc}): {err[-600:]}")
+        raise SystemExit(0)
 
-    # 1d. Symlink launcher into ~/.local/bin/hermes.
-    if hermes_venv_bin.exists():
-        if hermes_bin.exists() or hermes_bin.is_symlink():
-            hermes_bin.unlink()
-        hermes_bin.symlink_to(hermes_venv_bin)
-        print(f"Hermes Agent installed -> {hermes_bin} -> {hermes_venv_bin}")
+    if hermes_bin.exists():
+        print(f"Hermes Agent installed at {hermes_bin}")
     else:
-        print(f"Warning: expected venv binary missing: {hermes_venv_bin}")
+        print(f"Warning: uv tool install succeeded but {hermes_bin} not found")
 else:
     print(f"Hermes Agent already installed at {hermes_bin}")
 
-# 1e. Pre-create standard Hermes runtime dirs so first run doesn't race on mkdir.
+# 2. Pre-create standard Hermes runtime dirs so first run doesn't race on mkdir.
 for sub in ("sessions", "logs", "memories", "skills", "cron", "pairing",
             "hooks", "image_cache", "audio_cache"):
     (hermes_home / sub).mkdir(parents=True, exist_ok=True)
 
-# 2. Skip auth config if no token (will be configured after PAT setup)
+# 3. Skip auth config if no token (will be configured after PAT setup)
 if not host or not token:
     print("Hermes Agent installed — config will be set after PAT setup")
     raise SystemExit(0)
@@ -165,7 +109,7 @@ else:
     auth_token = token
     print(f"Using Databricks Host: {host}")
 
-# 3. Write ~/.hermes/config.yaml
+# 4. Write ~/.hermes/config.yaml
 config_path = hermes_home / "config.yaml"
 
 claude_skills_dir = Path("/app/python/source_code/.claude/skills")
@@ -244,7 +188,7 @@ if should_write:
     config_path.write_text("\n".join(lines))
     print(f"Hermes config written: {config_path}")
 
-# 4. Adapt CLAUDE.md -> ~/.hermes/HERMES.md for first-run context
+# 5. Adapt CLAUDE.md -> ~/.hermes/HERMES.md for first-run context
 claude_md_locations = [
     Path(__file__).parent / "CLAUDE.md",
     home / ".claude" / "CLAUDE.md",
@@ -265,7 +209,7 @@ adapt_instructions_file(
     cli_name="Hermes",
 )
 
-# 5. Create projects directory (parity with other agents)
+# 6. Create projects directory (parity with other agents)
 projects_dir = home / "projects"
 projects_dir.mkdir(exist_ok=True)
 
@@ -278,5 +222,5 @@ print("  hermes mcp add <name> <url>    # Add MCP server")
 print(f"\nEndpoint:       {base_url}")
 print(f"Primary model:  {hermes_model}")
 print(f"Fallback model: {hermes_fallback_model} (auto-activates on 429/529/503)")
-print(f"Extras:         [{HERMES_EXTRAS}]  (add more: uv pip install -e \".[voice,...]\")")
+print(f"Install:        minimal  (add extras: uv pip install \"hermes-agent[mcp,messaging,...]\")")
 print("Auth:           Bearer token (Databricks PAT)")

--- a/setup_hermes.py
+++ b/setup_hermes.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python
+"""Configure Hermes Agent with Databricks Model Serving.
+
+Hermes Agent (github.com/NousResearch/hermes-agent) is a multi-provider AI CLI
+with tool-calling, persistent memory, slash commands, and a rich skill system.
+
+Unlike the other CLIs in CoDA, Hermes is a Python application (not npm).
+This script performs a LEAN install (bypassing the upstream installer's
+`.[all]` extras, which pull ~500 MB / 90+ packages) by cloning the repo
+and installing only the extras CoDA actually needs:
+
+    [mcp, messaging, matrix, web, acp]    # ~180 MB, ~90 s on Databricks Apps
+
+This covers Hermes's three CoDA-required capabilities:
+  1. Self-improvement via MCP (deepwiki, exa)
+  2. Pre-wired Databricks Model Serving (core dep — no extra needed)
+  3. Open path for messaging (WhatsApp / Slack / Teams / Matrix / Discord)
+
+Users can add more later via `uv pip install -e ".[voice,rl,feishu,...]"`
+inside ~/.hermes/hermes-agent, or via `hermes setup` / `hermes mcp add`.
+
+Config: ~/.hermes/config.yaml with custom provider for Databricks.
+Auth:   Bearer token via Databricks PAT.
+
+Config precedence (matches Claude/Codex/Gemini/OpenCode setup):
+  1. If DATABRICKS_GATEWAY_HOST or DATABRICKS_WORKSPACE_ID -> AI Gateway
+  2. Otherwise -> DATABRICKS_HOST/serving-endpoints
+
+Opt-out:
+  Set ENABLE_HERMES=false in app.yaml to skip installation entirely.
+"""
+import os
+import subprocess
+from pathlib import Path
+
+from utils import adapt_instructions_file, ensure_https, get_gateway_host
+
+# Opt-out: allow operators to disable Hermes bundling without removing the file.
+if os.environ.get("ENABLE_HERMES", "true").strip().lower() in ("false", "0", "no"):
+    print("ENABLE_HERMES=false — skipping Hermes Agent setup")
+    raise SystemExit(0)
+
+# Set HOME if not properly set
+if not os.environ.get("HOME") or os.environ["HOME"] == "/":
+    os.environ["HOME"] = "/app/python/source_code"
+
+home = Path(os.environ["HOME"])
+
+host = os.environ.get("DATABRICKS_HOST", "")
+token = os.environ.get("DATABRICKS_TOKEN", "")
+hermes_model = os.environ.get("HERMES_MODEL", "databricks-claude-opus-4-7")
+hermes_fallback_model = os.environ.get("HERMES_FALLBACK_MODEL", "databricks-claude-opus-4-6")
+
+hermes_home = home / ".hermes"
+hermes_install_dir = hermes_home / "hermes-agent"
+hermes_venv = hermes_install_dir / "venv"
+hermes_venv_bin = hermes_venv / "bin" / "hermes"
+hermes_bin = home / ".local" / "bin" / "hermes"
+
+# Lean extras — covers MCP (self-improvement), messaging paths (WhatsApp/Slack/
+# Teams via matrix bridges), and ACP (agent-to-agent protocol). Excludes voice,
+# rl, feishu, dingtalk, bedrock, mistral, modal, daytona — users opt in later.
+HERMES_EXTRAS = "mcp,messaging,matrix,web,acp"
+HERMES_REPO = "https://github.com/NousResearch/hermes-agent.git"
+
+# 1. Install Hermes Agent (always, even without token).
+local_bin = home / ".local" / "bin"
+local_bin.mkdir(parents=True, exist_ok=True)
+hermes_home.mkdir(parents=True, exist_ok=True)
+
+
+def _run(cmd, **kwargs):
+    """Run a subprocess command and return (rc, stdout, stderr)."""
+    result = subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+    return result.returncode, result.stdout, result.stderr
+
+
+if not hermes_bin.exists() or not hermes_venv_bin.exists():
+    print(f"Installing Hermes Agent (lean extras: [{HERMES_EXTRAS}])...")
+
+    # 1a. Clone (or update) the repo.
+    if not hermes_install_dir.exists():
+        rc, _, err = _run(
+            ["git", "clone", "--depth", "1", HERMES_REPO, str(hermes_install_dir)],
+            timeout=180,
+        )
+        if rc != 0:
+            print(f"Hermes git clone failed (rc={rc}): {err[-600:]}")
+            raise SystemExit(0)  # soft-fail — don't crash app startup
+    else:
+        # Best-effort pull; ignore failures (detached HEAD, local edits, etc.)
+        _run(["git", "-C", str(hermes_install_dir), "pull", "--ff-only"], timeout=60)
+
+    # 1b. Create venv with uv.
+    if not hermes_venv.exists():
+        rc, _, err = _run(
+            ["uv", "venv", str(hermes_venv)],
+            timeout=120,
+        )
+        if rc != 0:
+            print(f"Hermes venv create failed (rc={rc}): {err[-600:]}")
+            raise SystemExit(0)
+
+    # 1c. Install with lean extras using uv (fast + respects pyproject extras).
+    install_env = {
+        **os.environ,
+        "VIRTUAL_ENV": str(hermes_venv),
+        "PATH": f"{hermes_venv / 'bin'}:{os.environ.get('PATH', '')}",
+    }
+    rc, _, err = _run(
+        ["uv", "pip", "install", "-e", f".[{HERMES_EXTRAS}]"],
+        cwd=str(hermes_install_dir),
+        env=install_env,
+        timeout=600,
+    )
+    if rc != 0:
+        # Fall back to bare install so `hermes` at least launches.
+        print(f"Hermes lean install failed (rc={rc}), falling back to base: {err[-400:]}")
+        rc, _, err = _run(
+            ["uv", "pip", "install", "-e", "."],
+            cwd=str(hermes_install_dir),
+            env=install_env,
+            timeout=600,
+        )
+        if rc != 0:
+            print(f"Hermes base install also failed (rc={rc}): {err[-600:]}")
+            raise SystemExit(0)
+
+    # 1d. Symlink launcher into ~/.local/bin/hermes.
+    if hermes_venv_bin.exists():
+        if hermes_bin.exists() or hermes_bin.is_symlink():
+            hermes_bin.unlink()
+        hermes_bin.symlink_to(hermes_venv_bin)
+        print(f"Hermes Agent installed -> {hermes_bin} -> {hermes_venv_bin}")
+    else:
+        print(f"Warning: expected venv binary missing: {hermes_venv_bin}")
+else:
+    print(f"Hermes Agent already installed at {hermes_bin}")
+
+# 1e. Pre-create standard Hermes runtime dirs so first run doesn't race on mkdir.
+for sub in ("sessions", "logs", "memories", "skills", "cron", "pairing",
+            "hooks", "image_cache", "audio_cache"):
+    (hermes_home / sub).mkdir(parents=True, exist_ok=True)
+
+# 2. Skip auth config if no token (will be configured after PAT setup)
+if not host or not token:
+    print("Hermes Agent installed — config will be set after PAT setup")
+    raise SystemExit(0)
+
+# Strip trailing slash and ensure https:// prefix
+host = ensure_https(host.rstrip("/"))
+
+gateway_host = get_gateway_host()
+gateway_token = os.environ.get("DATABRICKS_TOKEN", "") if gateway_host else ""
+if gateway_host and not gateway_token:
+    print("Warning: AI Gateway resolved but DATABRICKS_TOKEN missing, falling back to DATABRICKS_HOST")
+    gateway_host = ""
+
+if gateway_host:
+    base_url = f"{gateway_host}/mlflow/v1"
+    auth_token = gateway_token
+    print(f"Using Databricks AI Gateway: {gateway_host}")
+else:
+    base_url = f"{host}/serving-endpoints"
+    auth_token = token
+    print(f"Using Databricks Host: {host}")
+
+# 3. Write ~/.hermes/config.yaml
+config_path = hermes_home / "config.yaml"
+
+claude_skills_dir = Path("/app/python/source_code/.claude/skills")
+external_skills = [str(claude_skills_dir)] if claude_skills_dir.exists() else []
+
+model_catalog = [
+    "databricks-claude-opus-4-6",
+    "databricks-claude-sonnet-4-6",
+    "databricks-claude-haiku-4-5",
+    "databricks-gpt-5-3-codex",
+    "databricks-gpt-5-1-codex-max",
+    "databricks-gemini-2-5-flash",
+    "databricks-gemini-2-5-pro",
+    "databricks-gemini-3-1-pro",
+]
+
+lines = []
+lines.append("# Hermes Agent config — generated by setup_hermes.py")
+lines.append("# Regenerate by re-running: uv run python setup_hermes.py")
+lines.append("")
+lines.append("model:")
+lines.append(f"  default: {hermes_model}")
+lines.append("  provider: custom")
+lines.append(f"  base_url: {base_url}")
+lines.append(f"  api_key: {auth_token}")
+lines.append("")
+lines.append("# Fallback chain — triggers on 429 (rate limit), 529 (overload),")
+lines.append("# 503 (service errors), or connection failures.")
+lines.append("fallback_providers:")
+lines.append("- provider: custom")
+lines.append(f"  model: {hermes_fallback_model}")
+lines.append(f"  base_url: {base_url}")
+lines.append(f"  api_key: {auth_token}")
+lines.append("")
+lines.append("# External skills — Claude Code skill directory (shared with other agents)")
+lines.append("skills:")
+if external_skills:
+    lines.append("  external_dirs:")
+    for d in external_skills:
+        lines.append(f"    - {d}")
+else:
+    lines.append("  external_dirs: []")
+lines.append("")
+lines.append("# Native MCP servers — DeepWiki (GitHub wiki lookup) + Exa (web search)")
+lines.append("mcp_servers:")
+lines.append("  deepwiki:")
+lines.append("    url: https://mcp.deepwiki.com/mcp")
+lines.append("    timeout: 60")
+lines.append("  exa:")
+lines.append("    url: https://mcp.exa.ai/mcp")
+lines.append("    timeout: 60")
+
+team_memory_url = os.environ.get("TEAM_MEMORY_MCP_URL", "").strip().rstrip("/")
+if team_memory_url:
+    lines.append("  team-memory:")
+    lines.append(f"    url: {team_memory_url}/mcp")
+    lines.append("    timeout: 60")
+    print(f"Team memory MCP configured: {team_memory_url}/mcp")
+
+lines.append("")
+lines.append("# Model catalog hint — users can `/model` switch inside chat")
+lines.append("display:")
+lines.append("  known_models:")
+for m in model_catalog:
+    lines.append(f"    - {m}")
+lines.append("")
+
+should_write = True
+if config_path.exists():
+    existing = config_path.read_text()
+    if "generated by setup_hermes.py" not in existing and "provider: custom" in existing:
+        print(f"Existing {config_path} looks hand-edited — preserving it (skipping rewrite)")
+        should_write = False
+
+if should_write:
+    config_path.write_text("\n".join(lines))
+    print(f"Hermes config written: {config_path}")
+
+# 4. Adapt CLAUDE.md -> ~/.hermes/HERMES.md for first-run context
+claude_md_locations = [
+    Path(__file__).parent / "CLAUDE.md",
+    home / ".claude" / "CLAUDE.md",
+    Path("/app/python/source_code/CLAUDE.md"),
+]
+
+claude_md_path = None
+for loc in claude_md_locations:
+    if loc.exists():
+        claude_md_path = loc
+        break
+
+hermes_md = hermes_home / "HERMES.md"
+adapt_instructions_file(
+    source_path=claude_md_path or claude_md_locations[0],
+    target_path=hermes_md,
+    new_header="# Hermes Agent on Databricks",
+    cli_name="Hermes",
+)
+
+# 5. Create projects directory (parity with other agents)
+projects_dir = home / "projects"
+projects_dir.mkdir(exist_ok=True)
+
+print("\nHermes Agent ready! Usage:")
+print("  hermes chat                    # Interactive chat")
+print("  hermes --tui chat              # Rich Ink TUI")
+print("  hermes model                   # Select default model")
+print("  hermes setup                   # Reconfigure wizard")
+print("  hermes mcp add <name> <url>    # Add MCP server")
+print(f"\nEndpoint:       {base_url}")
+print(f"Primary model:  {hermes_model}")
+print(f"Fallback model: {hermes_fallback_model} (auto-activates on 429/529/503)")
+print(f"Extras:         [{HERMES_EXTRAS}]  (add more: uv pip install -e \".[voice,...]\")")
+print("Auth:           Bearer token (Databricks PAT)")

--- a/setup_hermes.py
+++ b/setup_hermes.py
@@ -123,7 +123,7 @@ model_catalog = [
     "databricks-gpt-5-1-codex-max",
     "databricks-gemini-2-5-flash",
     "databricks-gemini-2-5-pro",
-    "databricks-gemini-3-1-pro",
+    "databricks-gemini-2-5-pro",
 ]
 
 lines = []

--- a/setup_hermes.py
+++ b/setup_hermes.py
@@ -49,7 +49,9 @@ hermes_bin = home / ".local" / "bin" / "hermes"
 # Minimal install from git — core deps (openai, anthropic, prompt_toolkit, rich,
 # httpx, pyyaml, pydantic) cover chat + Databricks model serving. Not on PyPI,
 # so we install directly from GitHub. uv tool install handles venv + binary.
+# The mcp package is needed for HTTP transport (DeepWiki, Exa MCP servers).
 HERMES_PKG = "hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git"
+HERMES_EXTRA_DEPS = ["mcp>=1.2.0"]
 
 # 1. Install Hermes Agent (always, even without token).
 local_bin = home / ".local" / "bin"
@@ -66,8 +68,13 @@ def _run(cmd, **kwargs):
 if not hermes_bin.exists():
     print("Installing Hermes Agent from PyPI (minimal)...")
 
+    install_cmd = ["uv", "tool", "install"]
+    for dep in HERMES_EXTRA_DEPS:
+        install_cmd.extend(["--with", dep])
+    install_cmd.append(HERMES_PKG)
+
     rc, _, err = _run(
-        ["uv", "tool", "install", HERMES_PKG],
+        install_cmd,
         timeout=600,
     )
     if rc != 0:

--- a/setup_opencode.py
+++ b/setup_opencode.py
@@ -134,8 +134,8 @@ if gateway_host:
                             "output": 8192
                         }
                     },
-                    "databricks-gemini-3-1-pro": {
-                        "name": "Gemini 3.1 Pro (Databricks)",
+                    "databricks-gemini-2-5-pro": {
+                        "name": "Gemini 2.5 Pro (Databricks)",
                         "limit": {
                             "context": 1000000,
                             "output": 8192
@@ -226,8 +226,8 @@ else:
                             "output": 8192
                         }
                     },
-                    "databricks-gemini-3-1-pro": {
-                        "name": "Gemini 3.1 Pro (Databricks)",
+                    "databricks-gemini-2-5-pro": {
+                        "name": "Gemini 2.5 Pro (Databricks)",
                         "limit": {
                             "context": 1000000,
                             "output": 8192


### PR DESCRIPTION
## Summary
Integrate Hermes Agent as the 5th coding CLI in CoDA, plus auth fixes for Hermes and Gemini.

### Commits
- **feat: integrate Hermes Agent as 5th coding CLI** — setup script, config generation, PAT rotation support, onboarding docs
- **fix: replace 135MB git clone with uv tool install** — original setup timed out on Databricks Apps; now uses `uv tool install` from git URL
- **fix: post-setup token sync** — prevents stale PAT when setup finishes after first rotation (race condition where `_update_hermes()` silently skipped missing config)
- **fix: Gemini CLI auth** — removed quoted `"bearer"` in `.env` (Node.js dotenv included quotes in value); stripped stale `GEMINI_API_KEY` from terminal session env
- **chore: update default Gemini model** — `databricks-gemini-3-1-pro` → `databricks-gemini-2-5-pro`

## Test plan

### Hermes Agent
- [x] `/api/setup-status` shows hermes step completing (not stuck/pending)
- [x] `which hermes` returns `~/.local/bin/hermes` in a terminal session
- [x] `cat ~/.hermes/config.yaml` shows `provider: custom` + correct AI Gateway endpoint
- [x] `hermes chat` connects and can send/receive messages
- [x] After ~10 min (PAT rotation), `cat ~/.hermes/config.yaml` shows updated `api_key:` value
- [x] Launching `hermes chat` after rotation works without 403

### Gemini CLI
- [x] `gemini` CLI starts without prompting for GEMINI_API_KEY / Vertex / GCA
- [x] `cat ~/.gemini/.env` shows `GEMINI_API_KEY_AUTH_MECHANISM=bearer` (no quotes)
- [x] `env | grep GEMINI_API_KEY` in terminal session returns empty (stripped from env)
- [x] Gemini uses `databricks-gemini-2-5-pro` model by default

### Token rotation (all CLIs)
- [x] After first PAT rotation, check all config files have the new token:
  - `~/.claude/settings.json` → `ANTHROPIC_AUTH_TOKEN`
  - `~/.codex/.env` → `OPENAI_API_KEY`
  - `~/.gemini/.env` → `GEMINI_API_KEY`
  - `~/.hermes/config.yaml` → `api_key:` (both primary and fallback)
  - `~/.local/share/opencode/auth.json` → `api_key`
- [x] All CLIs work after rotation without restart

### Post-setup token sync
- [x] Deploy fresh app, create session immediately (before 10-min rotation)
- [x] All CLI configs should have valid token (not the stale boot token)