### PR TITLE
feat: add BDD testing skills (bdd-scaffold, bdd-features, bdd-steps, bdd-run)

### DIFF
--- a/.claude/skills/bdd-features/SKILL.md
+++ b/.claude/skills/bdd-features/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: bdd-features
+description: "This skill should be used when the user asks to \"write Gherkin\", \"create feature files\", \"generate BDD scenarios\", \"write acceptance tests in Gherkin\", \"create Behave features\", \"write Given When Then tests\", \"BDD test cases for my pipeline\", \"Gherkin for Unity Catalog\", or wants to translate requirements into Gherkin feature files for Databricks."
+user-invocable: true
+---
+
+# BDD Features — Gherkin Feature File Generation
+
+Generate well-structured Gherkin `.feature` files for Databricks workloads. Translate requirements, user stories, or existing code into behavior specifications using Given/When/Then syntax.
+
+## When to use
+
+- Translating requirements or user stories into Gherkin acceptance criteria
+- Creating feature files for Databricks pipelines, catalog permissions, jobs, or Apps
+- Writing regression tests in Gherkin for existing functionality
+- Generating Scenario Outlines for data-driven testing
+
+## Process
+
+### 1. Identify the test subject
+
+Determine what to test. Read the relevant code or ask the user:
+
+- A Lakeflow SDP pipeline definition → pipeline behavior tests
+- Unity Catalog grants/policies → permission verification tests
+- A FastAPI Databricks App → API endpoint tests
+- A notebook or job → execution and output validation tests
+- SQL transformations → data quality and correctness tests
+
+### 2. Write the feature file
+
+Place feature files in the appropriate subdirectory under `features/`:
+
+```
+features/
+├── catalog/permissions.feature
+├── pipelines/events_pipeline.feature
+├── apps/api_endpoints.feature
+├── jobs/etl_notebook.feature
+└── sql/data_quality.feature
+```
+
+**Structure every feature file with:**
+
+1. **Tags** — `@domain`, `@smoke`/`@regression`/`@integration`, optional `@slow` or `@wip`
+2. **Feature header** — name + As a / I want / So that narrative
+3. **Background** — shared Given steps (workspace connection, test schema)
+4. **Scenarios** — one behavior per scenario, descriptive names
+
+Refer to `references/gherkin-patterns.md` for Databricks-specific Gherkin patterns covering:
+- Pipeline lifecycle (full refresh, incremental, failure handling)
+- Unity Catalog grants, column masks, row filters
+- App endpoint testing with SSO headers
+- Job/notebook execution and output validation
+- SQL data quality assertions
+- Scenario Outlines for parameterized testing
+
+### 3. Gherkin writing principles
+
+**Declarative, not imperative.** Describe *what* the system should do, not *how* to click buttons:
+
+```gherkin
+# Good — declarative
+When I grant SELECT on "catalog.schema.table" to group "readers"
+Then the group "readers" should have SELECT permission
+
+# Bad — imperative
+When I open the Catalog Explorer
+And I click on the table "catalog.schema.table"
+And I click "Permissions"
+And I click "Grant"
+And I select "SELECT"
+And I type "readers" in the group field
+And I click "Save"
+```
+
+**One behavior per scenario.** If a scenario tests two independent things, split it.
+
+**Use Backgrounds for shared setup.** Avoid repeating connection/schema steps across scenarios.
+
+**Scenario Outlines for data variations.** When the same behavior is tested with different inputs, use Examples tables instead of duplicating scenarios.
+
+**Tag strategically:**
+- `@smoke` — fast, critical-path tests (< 30 seconds each)
+- `@regression` — thorough coverage (minutes)
+- `@integration` — needs live workspace (skip in unit test CI)
+- `@slow` — pipeline tests, job executions (> 2 minutes)
+
+**CRITICAL — Curly braces break step matching.** Behave uses the `parse` library for step matching. `{anything}` in feature file text is interpreted as a capture group, not a literal. Never use `{test_schema}.table_name` in feature files — it will fail to match step definitions. Instead, use short table names (`"customers"`) and resolve the schema in step code.
+
+**Trailing colons matter.** When a step has an attached data table or docstring, the `:` at the end of the Gherkin line IS part of the step text. The step pattern must include it: `@given('a table "{name}" with data:')` — not `with data` (no colon).
+
+### 4. Validate step coverage
+
+After writing features, check that step definitions exist for all steps:
+
+```bash
+uv run behave --dry-run
+```
+
+Any undefined steps will be reported with suggested snippets. Hand those to the `bdd-steps` skill for implementation.
+
+## Additional resources
+
+- **`references/gherkin-patterns.md`** — Complete Databricks Gherkin pattern library with examples for every domain

--- a/.claude/skills/bdd-features/references/gherkin-patterns.md
+++ b/.claude/skills/bdd-features/references/gherkin-patterns.md
@@ -1,0 +1,446 @@
+# Gherkin Patterns for Databricks
+
+Reusable Gherkin patterns for common Databricks testing scenarios. Copy and adapt these to feature files.
+
+> **WARNING: Curly braces in step text break Behave's `parse` matcher.**
+>
+> Behave uses Python's `parse` library for step matching. Any `{...}` in step text
+> is interpreted as a capture group. Writing `{test_schema}.customers` in a step line
+> will **silently fail to match** your step definition.
+>
+> **The correct pattern:**
+> - Step text uses **short table names in quotes**: `"customers"`, `"orders"`
+> - SQL inside **docstrings** (triple-quoted blocks) can safely use `{schema}` because
+>   docstrings are accessed via `context.text`, not step matching
+> - Step definitions prepend `context.test_schema + "."` internally to build the FQN
+>
+> ```python
+> # WRONG - step text with curly braces
+> @given('a table "{test_schema}.customers" exists')   # BROKEN - parse eats {test_schema}
+>
+> # RIGHT - short name in step text, FQN built in the step body
+> @given('a managed table "{table_name}" exists')
+> def step_impl(context, table_name):
+>     fqn = f"{context.test_schema}.{table_name}"
+>     # ... use fqn
+> ```
+>
+> **Docstring SQL pattern** (safe because `context.text` is just a string):
+> ```python
+> @when('I execute SQL:')
+> def step_impl(context):
+>     sql = context.text.replace("{schema}", context.test_schema)
+>     # ... execute sql
+> ```
+
+## Common Background
+
+Most Databricks feature files share this Background:
+
+```gherkin
+Background:
+  Given a Databricks workspace connection is established
+  And a test schema is provisioned
+```
+
+---
+
+## Unity Catalog
+
+### Table permissions
+
+```gherkin
+@catalog @permissions
+Feature: Unity Catalog table permissions
+  As a data engineer
+  I want to verify table-level permissions
+  So that sensitive data is properly protected
+
+  Background:
+    Given a Databricks workspace connection is established
+    And a test schema is provisioned
+
+  Scenario: Grant SELECT to a group
+    Given a managed table "customers" exists
+    When I execute SQL:
+      """sql
+      GRANT SELECT ON TABLE {schema}.customers TO `data_readers`
+      """
+    And I execute SQL:
+      """sql
+      SHOW GRANTS ON TABLE {schema}.customers
+      """
+    Then the result should contain a row where "ActionType" is "SELECT" and "Principal" is "data_readers"
+
+  Scenario Outline: Verify multiple privilege types
+    Given a managed table "sales" exists
+    When I execute SQL:
+      """sql
+      GRANT <privilege> ON TABLE {schema}.sales TO `<group>`
+      """
+    And I execute SQL:
+      """sql
+      SHOW GRANTS ON TABLE {schema}.sales
+      """
+    Then the result should contain a row where "ActionType" is "<privilege>" and "Principal" is "<group>"
+
+    Examples:
+      | privilege | group         |
+      | SELECT    | data_readers  |
+      | MODIFY    | data_writers  |
+```
+
+### Column masks
+
+```gherkin
+@catalog @security
+Feature: Column-level security
+
+  Background:
+    Given a Databricks workspace connection is established
+    And a test schema is provisioned
+
+  Scenario: Mask PII columns for analysts
+    Given a managed table "customers" with columns:
+      | column_name | data_type | contains_pii |
+      | id          | BIGINT    | false        |
+      | name        | STRING    | true         |
+      | email       | STRING    | true         |
+      | region      | STRING    | false        |
+    And a column mask function "mask_pii" is applied to "name" and "email" on "customers"
+    When I query "customers" as group "analysts"
+    Then columns "name" and "email" should return masked values
+    But columns "id" and "region" should return actual values
+```
+
+### Row filters
+
+```gherkin
+@catalog @security
+Feature: Row-level security
+
+  Background:
+    Given a Databricks workspace connection is established
+    And a test schema is provisioned
+
+  Scenario: Row filter restricts by region
+    Given a managed table "regional_sales" with data:
+      | region | revenue | quarter |
+      | APAC   | 50000   | Q1      |
+      | EMEA   | 75000   | Q1      |
+      | AMER   | 100000  | Q1      |
+    And a row filter on "regional_sales" restricts "apac_analysts" to region "APAC"
+    When I query "regional_sales" as group "apac_analysts"
+    Then I should only see rows where "region" is "APAC"
+    And the result should have 1 row
+```
+
+---
+
+## Lakeflow Spark Declarative Pipelines
+
+### Pipeline lifecycle
+
+```gherkin
+@pipeline @lakeflow
+Feature: Events pipeline processing
+  As a data engineer
+  I want to verify the events pipeline processes data correctly
+  So that downstream consumers get accurate aggregations
+
+  Background:
+    Given a Databricks workspace connection is established
+    And a test schema is provisioned
+
+  @integration @slow
+  Scenario: Full refresh produces expected tables
+    Given a pipeline "events_pipeline" exists targeting the test schema
+    When I trigger a full refresh of the pipeline
+    Then the pipeline update should succeed within 600 seconds
+    And the streaming table "bronze_events" should exist
+    And the materialized view "silver_events_agg" should exist
+    And the table "silver_events_agg" should have more than 0 rows
+
+  @integration
+  Scenario: Incremental refresh picks up new data
+    Given the pipeline "events_pipeline" has completed a full refresh
+    When I insert test records into the source
+    And I trigger an incremental refresh of the pipeline
+    Then the pipeline update should succeed within 300 seconds
+    And the new records should appear in "bronze_events"
+
+  Scenario: Pipeline handles empty source gracefully
+    Given a pipeline "events_pipeline" exists targeting the test schema
+    And the source table is empty
+    When I trigger a full refresh of the pipeline
+    Then the pipeline update should succeed within 300 seconds
+    And the streaming table "bronze_events" should have 0 rows
+```
+
+### Pipeline failure handling
+
+```gherkin
+  Scenario: Pipeline surfaces schema mismatch errors
+    Given a pipeline "events_pipeline" exists targeting the test schema
+    And the source table has an unexpected column "extra_col" of type "BINARY"
+    When I trigger a full refresh of the pipeline
+    Then the pipeline update should fail
+    And the pipeline error should mention schema
+```
+
+---
+
+## Jobs and Notebooks
+
+### Notebook execution
+
+```gherkin
+@jobs @notebook
+Feature: Customer ETL notebook
+  As a data engineer
+  I want to verify the ETL notebook produces correct output
+
+  Background:
+    Given a Databricks workspace connection is established
+    And a test schema is provisioned
+
+  @integration @slow
+  Scenario: Dedup notebook removes duplicates
+    Given a managed table "raw_customers" with data:
+      | customer_id | name     | email             | updated_at          |
+      | 1           | Alice    | alice@example.com | 2024-01-01T00:00:00 |
+      | 1           | Alice B. | alice@example.com | 2024-06-01T00:00:00 |
+      | 2           | Bob      | bob@example.com   | 2024-03-15T00:00:00 |
+    When I run the notebook "/Repos/team/etl/customer_dedup" with parameters:
+      | key          | value          |
+      | source_table | raw_customers  |
+      | target_table | clean_customers|
+    Then the job should complete with status "SUCCESS" within 300 seconds
+    And the table "clean_customers" should have 2 rows
+    And the table "clean_customers" should contain a row where "customer_id" is "1" and "name" is "Alice B."
+
+  Scenario: Notebook fails gracefully on missing source
+    When I run the notebook "/Repos/team/etl/customer_dedup" with parameters:
+      | key          | value          |
+      | source_table | nonexistent    |
+      | target_table | output         |
+    Then the job should complete with status "FAILED" within 120 seconds
+```
+
+---
+
+## Databricks Apps (FastAPI)
+
+### API endpoint testing
+
+```gherkin
+@app @fastapi
+Feature: Databricks App API
+  As a user
+  I want the app endpoints to work correctly
+
+  Background:
+    Given the app is running at the configured base URL
+    And the test user is "testuser@databricks.com"
+
+  @smoke
+  Scenario: Health check
+    When I GET "/health"
+    Then the response status should be 200
+    And the response JSON should contain "status" with value "healthy"
+
+  Scenario: Authenticated user can list resources
+    When I GET "/api/dashboards" with auth headers
+    Then the response status should be 200
+    And the response should be a JSON list
+
+  Scenario: Unauthenticated request is rejected
+    When I GET "/api/dashboards" without auth headers
+    Then the response status should be 401
+
+  Scenario: POST creates a resource
+    When I POST "/api/items" with auth headers and body:
+      """json
+      {"name": "Test Item", "description": "Created by BDD test"}
+      """
+    Then the response status should be 201
+    And the response JSON should contain "name" with value "Test Item"
+```
+
+### App deployment testing
+
+```gherkin
+@app @deployment @slow
+Feature: App deployment lifecycle
+  Scenario: Deploy and verify app is running
+    Given a bundle project at the repository root
+    When I deploy using Asset Bundles with target "dev"
+    Then the deployment should succeed
+    And the app should reach "RUNNING" state within 120 seconds
+    And the app health endpoint should return 200
+```
+
+---
+
+## SQL Data Quality
+
+### Row counts and data validation
+
+```gherkin
+@sql @data-quality
+Feature: Data quality checks
+
+  Background:
+    Given a Databricks workspace connection is established
+    And a test schema is provisioned
+
+  @smoke
+  Scenario: Table is not empty
+    Given the table "orders" has been loaded
+    Then the table "orders" should have more than 0 rows
+
+  Scenario: No duplicate primary keys
+    Given the table "orders" has been loaded
+    When I execute SQL:
+      """sql
+      SELECT order_id, COUNT(*) as cnt
+      FROM {schema}.orders
+      GROUP BY order_id
+      HAVING COUNT(*) > 1
+      """
+    Then the result should have 0 rows
+
+  Scenario: Foreign key integrity
+    Given the tables "orders" and "customers" have been loaded
+    When I execute SQL:
+      """sql
+      SELECT o.customer_id
+      FROM {schema}.orders o
+      LEFT JOIN {schema}.customers c ON o.customer_id = c.customer_id
+      WHERE c.customer_id IS NULL
+      """
+    Then the result should have 0 rows
+
+  Scenario: No null values in required columns
+    When I execute SQL:
+      """sql
+      SELECT COUNT(*) as null_count
+      FROM {schema}.orders
+      WHERE order_id IS NULL OR customer_id IS NULL OR order_date IS NULL
+      """
+    Then the first row column "null_count" should be "0"
+
+  Scenario: Verify GRANT was applied via SQL
+    Given a managed table "products" exists
+    When I execute SQL:
+      """sql
+      GRANT SELECT ON TABLE {schema}.products TO `reporting_team`
+      """
+    And I execute SQL:
+      """sql
+      SHOW GRANTS ON TABLE {schema}.products
+      """
+    Then the result should contain a row where "ActionType" is "SELECT" and "Principal" is "reporting_team"
+```
+
+---
+
+## Asset Bundles Deployment
+
+```gherkin
+@deployment @dabs
+Feature: Bundle lifecycle
+  @smoke
+  Scenario: Bundle validates successfully
+    When I run "databricks bundle validate" with target "dev"
+    Then the command should exit with code 0
+
+  @integration @slow
+  Scenario: Deploy and destroy lifecycle
+    When I run "databricks bundle deploy" with target "dev"
+    Then the command should exit with code 0
+    When I run "databricks bundle destroy" with target "dev" and auto-approve
+    Then the command should exit with code 0
+```
+
+---
+
+## Scenario Outline patterns
+
+Use Scenario Outlines for testing multiple variations of the same behavior.
+
+Note: table names in the Examples table are short names (no schema prefix). The step
+definition prepends `context.test_schema` to build the fully-qualified name.
+
+```gherkin
+  Scenario Outline: Verify table existence after pipeline run
+    Then the <table_type> "<table_name>" should exist
+
+    Examples: Streaming tables
+      | table_type      | table_name         |
+      | streaming table | bronze_events      |
+      | streaming table | bronze_transactions|
+
+    Examples: Materialized views
+      | table_type        | table_name       |
+      | materialized view | silver_events_agg|
+      | materialized view | gold_summary     |
+```
+
+---
+
+## Steps with data tables and docstrings
+
+Steps that accept a data table or docstring **must** end with a trailing colon. The colon
+is part of the step text that Behave matches against your `@given`/`@when`/`@then` decorator.
+
+```gherkin
+# CORRECT - colon before data table
+Given a managed table "customers" with data:
+  | id | name  | region |
+  | 1  | Alice | APAC   |
+  | 2  | Bob   | EMEA   |
+
+# CORRECT - colon before docstring
+When I execute SQL:
+  """sql
+  SELECT * FROM {schema}.customers
+  """
+
+# WRONG - missing colon, Behave will not match the step
+Given a managed table "customers" with data
+  | id | name  | region |
+```
+
+---
+
+## SHOW GRANTS column names
+
+`SHOW GRANTS` returns PascalCase column names. Use these exact names when asserting
+on grant results:
+
+| Column       | Description                                    |
+|--------------|------------------------------------------------|
+| `Principal`  | The user, group, or service principal           |
+| `ActionType` | The privilege (SELECT, MODIFY, ALL PRIVILEGES) |
+| `ObjectType` | TABLE, SCHEMA, CATALOG, etc.                   |
+| `ObjectKey`  | The fully-qualified object name                |
+
+---
+
+## Tag strategy
+
+| Tag | Purpose | Typical runtime |
+|-----|---------|----------------|
+| `@smoke` | Critical path, must always pass | < 30s per scenario |
+| `@regression` | Full coverage | Minutes |
+| `@integration` | Needs live workspace | Varies |
+| `@slow` | Pipeline/job execution | > 2 min |
+| `@wip` | Work in progress, skip by default | N/A |
+| `@skip` | Explicitly disabled | N/A |
+| `@catalog` | Unity Catalog tests | Varies |
+| `@pipeline` | Lakeflow SDP tests | Minutes |
+| `@jobs` | Job/notebook tests | Minutes |
+| `@app` | Databricks Apps tests | Seconds |
+| `@sql` | SQL/data quality tests | Seconds |
+| `@deployment` | DABs lifecycle tests | Minutes |

--- a/.claude/skills/bdd-run/SKILL.md
+++ b/.claude/skills/bdd-run/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: bdd-run
+description: "This skill should be used when the user asks to \"run BDD tests\", \"execute Behave\", \"run Gherkin tests\", \"run my feature files\", \"behave test results\", \"run smoke tests\", \"BDD test report\", or needs to execute Behave test suites with specific options like tag filtering, parallel execution, or CI reporting."
+user-invocable: true
+---
+
+# BDD Run — Execute and Report Behave Tests
+
+Execute Behave test suites with tag filtering, parallel execution, output formatting, and CI integration. Diagnose failures and suggest fixes.
+
+## When to use
+
+- Running the full BDD test suite or a subset by tags
+- Getting JUnit/JSON reports for CI pipelines
+- Re-running only failed scenarios
+- Running tests in parallel for speed
+- Diagnosing and triaging test failures
+
+## Process
+
+### 1. Pre-flight checks
+
+Before running tests, verify the environment:
+
+```bash
+# Verify Behave is installed
+uv run behave --version
+
+# Verify Databricks auth
+uv run python -c "from databricks.sdk import WorkspaceClient; print(WorkspaceClient().current_user.me().user_name)"
+
+# Dry run to check step coverage
+uv run behave --dry-run
+```
+
+If any undefined steps are found, report them and suggest using the `bdd-steps` skill.
+
+### 2. Execute tests
+
+**Run by tag (most common):**
+
+```bash
+# Smoke tests only
+uv run behave --tags="@smoke" --format=pretty
+
+# All except slow and WIP
+uv run behave --tags="not @slow and not @wip"
+
+# Specific domain
+uv run behave --tags="@catalog"
+uv run behave --tags="@pipeline"
+
+# Boolean combinations
+uv run behave --tags="(@catalog or @pipeline) and @smoke"
+```
+
+**Run specific feature file or directory:**
+
+```bash
+uv run behave features/catalog/permissions.feature
+uv run behave features/pipelines/
+```
+
+**Run by scenario name:**
+
+```bash
+uv run behave --name "Grant SELECT on a table"
+```
+
+**Pass runtime configuration:**
+
+```bash
+uv run behave -D warehouse_id=abc123 -D catalog=my_catalog -D environment=dev
+```
+
+### 3. Output and reporting
+
+**For local development:**
+
+```bash
+uv run behave --format=pretty --show-timings
+```
+
+**For CI pipelines (JUnit XML):**
+
+```bash
+uv run behave --junit --junit-directory=reports/behave/ --format=progress
+```
+
+**JSON output for programmatic analysis:**
+
+```bash
+uv run behave --format=json --outfile=reports/results.json --format=progress
+```
+
+**Multiple formatters simultaneously:**
+
+```bash
+uv run behave --format=pretty --format=json --outfile=reports/results.json
+```
+
+### 4. Re-run failed tests
+
+Configure rerun file output, then re-run only failures:
+
+```bash
+# First run captures failures
+uv run behave --format=rerun --outfile=reports/rerun.txt --format=pretty
+
+# Re-run only failed scenarios
+uv run behave @reports/rerun.txt
+```
+
+### 5. Parallel execution
+
+Behave has no built-in parallelism. Use `behavex` for parallel feature execution:
+
+```bash
+uv run behavex --parallel-processes 4 --parallel-scheme feature
+```
+
+Each parallel worker needs its own test schema to avoid cross-contamination. The `environment.py` template from `bdd-scaffold` handles this by using timestamped schema names with worker ID suffixes.
+
+### 6. Failure diagnosis
+
+When tests fail, read the output and categorize:
+
+| Failure type | Symptom | Action |
+|-------------|---------|--------|
+| Undefined step | `NotImplementedError` or "undefined" in output | Generate step with `bdd-steps` |
+| Auth failure | `PermissionDenied`, 401/403 | Check `databricks auth profiles` |
+| Timeout | `TimeoutError` in polling steps | Increase timeout parameter or check resource state |
+| Data mismatch | Assertion error with expected vs. actual | Check test data setup or query logic |
+| Schema not found | `SCHEMA_NOT_FOUND` | Verify `before_all` created the ephemeral schema |
+| Warehouse stopped | `WAREHOUSE_NOT_RUNNING` | Start warehouse or use `@fixture.sql_warehouse` tag hook |
+
+### 7. Makefile integration
+
+If a Makefile exists, prefer `make` targets:
+
+```bash
+make bdd           # Full suite
+make bdd-smoke     # Smoke tests
+make bdd-report    # JUnit for CI
+```

--- a/.claude/skills/bdd-scaffold/SKILL.md
+++ b/.claude/skills/bdd-scaffold/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: bdd-scaffold
+description: "This skill should be used when the user asks to \"set up BDD\", \"create a Behave project\", \"scaffold BDD tests\", \"initialize Behave\", \"add BDD to my project\", \"set up Gherkin testing\", \"create test structure for Behave\", or mentions setting up behavior-driven development testing. Generates a complete Behave project structure wired to Databricks SDK."
+user-invocable: true
+---
+
+# BDD Scaffold — Behave + Databricks Project Setup
+
+Generate a complete Python Behave project structure pre-wired with Databricks SDK integration, including `environment.py` hooks, test isolation via ephemeral schemas, and `behave.ini` configuration.
+
+## When to use
+
+- Starting a new BDD test suite for a Databricks project
+- Adding Behave-based acceptance tests to an existing repo
+- Setting up integration testing against Unity Catalog, pipelines, jobs, or Apps
+
+## Process
+
+### 1. Detect project context
+
+Identify the project root and existing tooling:
+
+```bash
+git rev-parse --show-toplevel
+```
+
+Check for existing test infrastructure: `pyproject.toml`, `Makefile`, `behave.ini`, `features/` directory. If a `features/` directory already exists, confirm before overwriting.
+
+### 2. Determine test domains
+
+Ask (or infer from the codebase) which Databricks domains to scaffold step files for:
+
+| Domain | Step file | When |
+|--------|-----------|------|
+| Unity Catalog | `catalog_steps.py` | Tables, schemas, grants, row filters, column masks |
+| Pipelines | `pipeline_steps.py` | Lakeflow SDP, streaming tables, materialized views |
+| Jobs | `job_steps.py` | Notebook runs, workflow tasks, job clusters |
+| Apps | `app_steps.py` | FastAPI endpoints, SSO headers, deployment |
+| SQL | `sql_steps.py` | Statement execution, warehouse queries, data validation |
+
+Always generate `common_steps.py` (shared workspace connection, row counting, table existence checks).
+
+### 3. Generate the directory structure
+
+```
+features/
+├── environment.py           # Databricks SDK setup, ephemeral schema lifecycle
+├── steps/
+│   ├── common_steps.py      # Shared steps (always generated)
+│   └── <domain>_steps.py    # Per-domain (based on step 2)
+├── catalog/                 # Feature file directories (one per domain)
+├── pipelines/
+├── jobs/
+├── apps/
+└── sql/
+behave.ini
+Makefile                     # (append BDD targets if Makefile exists)
+```
+
+Refer to `references/environment-template.md` for the full `environment.py` template with:
+- `before_all`: WorkspaceClient init, warehouse auto-discovery, ephemeral schema creation
+- `after_all`: Schema cascade drop
+- `before_scenario` / `after_scenario`: Per-scenario resource tracking and cleanup
+- Tag-based hooks for `@wip`, `@skip`, `@slow`
+
+Refer to `references/behave-config.md` for `behave.ini` and `pyproject.toml` configuration.
+
+### 4. Add dependencies
+
+If `pyproject.toml` exists and uses `uv`:
+
+```bash
+uv add --group test behave databricks-sdk httpx
+```
+
+If no `pyproject.toml`, create a minimal one with test dependencies.
+
+### 5. Add Makefile targets
+
+Append these targets (or create a Makefile if none exists):
+
+```makefile
+.PHONY: bdd bdd-smoke bdd-report
+
+bdd:
+	uv run behave --format=pretty
+
+bdd-smoke:
+	uv run behave --tags="@smoke" --format=pretty
+
+bdd-report:
+	uv run behave --junit --junit-directory=reports/ --format=progress
+```
+
+### 6. Verify scaffold
+
+Run `behave --dry-run` to confirm step discovery works and there are no import errors:
+
+```bash
+uv run behave --dry-run
+```
+
+Report the generated structure and next steps to the user.
+
+## Key design decisions
+
+- **Ephemeral schemas** — each test run creates a timestamped schema (`behave_test_YYYYMMDD_HHMMSS`) and drops it in `after_all`. Prevents cross-run contamination.
+- **`-D` userdata** for parameterization — warehouse IDs, catalog names, and targets are passed via CLI args, never hardcoded.
+- **Step files are globally scoped** in Behave — all files in `steps/` are imported regardless of which feature runs. Name step patterns carefully to avoid collisions.
+
+## Additional resources
+
+- **`references/environment-template.md`** — Full annotated environment.py template
+- **`references/behave-config.md`** — behave.ini and pyproject.toml configuration reference

--- a/.claude/skills/bdd-scaffold/references/behave-config.md
+++ b/.claude/skills/bdd-scaffold/references/behave-config.md
@@ -1,0 +1,134 @@
+# Behave Configuration Reference
+
+## behave.ini
+
+Standard Behave configuration file. Place at project root.
+
+```ini
+[behave]
+# Output
+default_format = pretty
+show_timings = true
+color = true
+
+# Default tag filter — skip WIP and explicitly skipped tests
+default_tags = not @wip and not @skip
+
+# Logging
+logging_level = INFO
+logging_format = %(asctime)s %(levelname)-8s %(name)s: %(message)s
+
+# Capture control
+stdout_capture = true
+log_capture = true
+
+# JUnit output (enable in CI)
+junit = false
+junit_directory = reports/
+
+# Feature paths
+paths = features/
+
+[behave.userdata]
+# Override with -D key=value on CLI
+warehouse_id = auto
+catalog = main
+environment = dev
+```
+
+## pyproject.toml
+
+Alternative configuration via pyproject.toml (Behave reads `[tool.behave]`):
+
+**IMPORTANT:** In `pyproject.toml`, `default_tags` must be a **list**, not a string. The `behave.ini` parser accepts a plain string, but the TOML parser is stricter:
+
+```toml
+[tool.behave]
+default_format = "pretty"
+show_timings = true
+default_tags = ["not @wip and not @skip"]  # MUST be a list in pyproject.toml
+junit = false
+junit_directory = "reports/"
+logging_level = "INFO"
+
+[tool.behave.userdata]
+warehouse_id = "auto"
+catalog = "main"
+environment = "dev"
+```
+
+## Dependencies
+
+Add to `pyproject.toml`:
+
+```toml
+[project.optional-dependencies]
+test = [
+    "behave>=1.2.6",
+    "databricks-sdk>=0.40.0",
+    "httpx>=0.27.0",
+]
+
+# Or for parallel execution
+test-parallel = [
+    "behave>=1.2.6",
+    "behavex>=3.0",
+    "databricks-sdk>=0.40.0",
+    "httpx>=0.27.0",
+]
+```
+
+With `uv`:
+
+```bash
+uv add --group test behave databricks-sdk httpx
+```
+
+## Makefile targets
+
+```makefile
+.PHONY: bdd bdd-smoke bdd-report bdd-rerun bdd-parallel bdd-dry-run
+
+bdd:
+	uv run behave --format=pretty --show-timings
+
+bdd-smoke:
+	uv run behave --tags="@smoke" --format=pretty
+
+bdd-report:
+	uv run behave --junit --junit-directory=reports/behave/ --format=progress
+
+bdd-rerun:
+	uv run behave @reports/rerun.txt
+
+bdd-parallel:
+	uv run behavex --parallel-processes 4 --parallel-scheme feature
+
+bdd-dry-run:
+	uv run behave --dry-run
+```
+
+## CI integration (GitHub Actions example)
+
+```yaml
+- name: Run BDD tests
+  env:
+    DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+    DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+    DATABRICKS_WAREHOUSE_ID: ${{ secrets.WAREHOUSE_ID }}
+    TEST_CATALOG: ci_test
+  run: |
+    uv run behave \
+      --tags="not @slow" \
+      --junit --junit-directory=reports/behave/ \
+      --format=progress \
+      -D catalog=$TEST_CATALOG \
+      -D warehouse_id=$DATABRICKS_WAREHOUSE_ID
+
+- name: Upload test results
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: behave-results
+    path: reports/behave/
+```

--- a/.claude/skills/bdd-scaffold/references/environment-template.md
+++ b/.claude/skills/bdd-scaffold/references/environment-template.md
@@ -1,0 +1,195 @@
+# environment.py Template — Databricks + Behave
+
+Complete annotated template for `features/environment.py`. Copy and adapt to the target project.
+
+## Full template
+
+```python
+"""Behave environment hooks — Databricks SDK integration.
+
+Sets up workspace connection, ephemeral test schema, and per-scenario cleanup.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+
+from behave.model import Feature, Scenario, Step
+from behave.runner import Context
+
+logger = logging.getLogger("behave.databricks")
+
+
+# ─── Session-level hooks ────────────────────────────────────────
+
+def before_all(context: Context) -> None:
+    """Initialize Databricks clients and create ephemeral test schema."""
+    from databricks.sdk import WorkspaceClient
+
+    context.workspace = WorkspaceClient()
+
+    # Fix host URL — some profiles include ?o=<org_id> which breaks SDK API paths.
+    # The CLI handles this transparently but the SDK does not.
+    if context.workspace.config.host and "?" in context.workspace.config.host:
+        clean_host = context.workspace.config.host.split("?")[0].rstrip("/")
+        profile = os.environ.get("DATABRICKS_CONFIG_PROFILE")
+        context.workspace = WorkspaceClient(profile=profile, host=clean_host)
+
+    # Verify auth
+    me = context.workspace.current_user.me()
+    context.current_user = me.user_name
+    logger.info("Authenticated as: %s", context.current_user)
+
+    # Warehouse — from -D userdata, env var, or auto-discover
+    userdata = context.config.userdata
+    context.warehouse_id = (
+        userdata.get("warehouse_id")
+        or os.environ.get("DATABRICKS_WAREHOUSE_ID")
+        or _discover_warehouse(context.workspace)
+    )
+    logger.info("Using warehouse: %s", context.warehouse_id)
+
+    # Catalog — from -D userdata or env var
+    context.test_catalog = userdata.get("catalog", os.environ.get("TEST_CATALOG", "main"))
+
+    # Create ephemeral schema (timestamped for isolation)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    worker = os.environ.get("BEHAVE_WORKER_ID", "0")
+    context.test_schema = f"{context.test_catalog}.behave_test_{ts}_w{worker}"
+
+    _execute_sql(context, f"CREATE SCHEMA IF NOT EXISTS {context.test_schema}")
+    logger.info("Created test schema: %s", context.test_schema)
+
+
+def after_all(context: Context) -> None:
+    """Drop ephemeral test schema."""
+    if hasattr(context, "test_schema"):
+        try:
+            _execute_sql(context, f"DROP SCHEMA IF EXISTS {context.test_schema} CASCADE")
+            logger.info("Dropped test schema: %s", context.test_schema)
+        except Exception as e:
+            logger.warning("Failed to drop test schema %s: %s", context.test_schema, e)
+
+
+# ─── Feature-level hooks ────────────────────────────────────────
+
+def before_feature(context: Context, feature: Feature) -> None:
+    """Log feature start. Skip if tagged @skip."""
+    logger.info("▶ Feature: %s", feature.name)
+    if "skip" in feature.tags:
+        feature.skip("Marked with @skip")
+
+
+def after_feature(context: Context, feature: Feature) -> None:
+    logger.info("◀ Feature: %s [%s]", feature.name, feature.status)
+
+
+# ─── Scenario-level hooks ───────────────────────────────────────
+
+def before_scenario(context: Context, scenario: Scenario) -> None:
+    """Initialize per-scenario state. Skip @wip scenarios."""
+    logger.info("  ▶ Scenario: %s", scenario.name)
+    if "wip" in scenario.tags:
+        scenario.skip("Work in progress")
+        return
+    # Track resources created during this scenario for cleanup
+    context.scenario_cleanup_sql = []
+
+
+def after_scenario(context: Context, scenario: Scenario) -> None:
+    """Clean up scenario-specific resources."""
+    for sql in getattr(context, "scenario_cleanup_sql", []):
+        try:
+            _execute_sql(context, sql)
+        except Exception as e:
+            logger.warning("Cleanup SQL failed: %s — %s", sql, e)
+    if scenario.status == "failed":
+        logger.error("  ✗ FAILED: %s", scenario.name)
+    else:
+        logger.info("  ◀ Scenario: %s [%s]", scenario.name, scenario.status)
+
+
+# ─── Step-level hooks ───────────────────────────────────────────
+
+def before_step(context: Context, step: Step) -> None:
+    context._step_start = datetime.now()
+
+
+def after_step(context: Context, step: Step) -> None:
+    elapsed = (datetime.now() - context._step_start).total_seconds()
+    if elapsed > 10:
+        logger.warning("    Slow step (%.1fs): %s %s", elapsed, step.keyword, step.name)
+    if step.status == "failed":
+        logger.error("    ✗ %s %s\n      %s", step.keyword, step.name, step.error_message)
+
+
+# ─── Tag-based hooks ────────────────────────────────────────────
+
+def before_tag(context, tag: str) -> None:
+    """Ensure resources for tagged scenarios."""
+    if tag == "fixture.sql_warehouse":
+        _ensure_warehouse_running(context)
+
+
+# ─── Helpers ────────────────────────────────────────────────────
+
+def _execute_sql(context: Context, sql: str) -> object:
+    """Execute a SQL statement via the Statement Execution API."""
+    return context.workspace.statement_execution.execute_statement(
+        warehouse_id=context.warehouse_id,
+        statement=sql,
+        wait_timeout="30s",
+    )
+
+
+def _discover_warehouse(workspace) -> str:
+    """Find the first available SQL warehouse."""
+    from databricks.sdk.service.sql import State
+
+    warehouses = list(workspace.warehouses.list())
+    # Prefer running warehouses
+    for wh in warehouses:
+        if wh.state == State.RUNNING:
+            return wh.id
+    if warehouses:
+        return warehouses[0].id
+    raise RuntimeError(
+        "No SQL warehouses found. Pass warehouse_id via -D warehouse_id=<id> "
+        "or set DATABRICKS_WAREHOUSE_ID."
+    )
+
+
+def _ensure_warehouse_running(context: Context) -> None:
+    """Start warehouse if stopped. Used by @fixture.sql_warehouse tag."""
+    from databricks.sdk.service.sql import State
+
+    wh = context.workspace.warehouses.get(context.warehouse_id)
+    if wh.state != State.RUNNING:
+        logger.info("Starting warehouse %s...", context.warehouse_id)
+        context.workspace.warehouses.start(context.warehouse_id)
+        context.workspace.warehouses.wait_get_warehouse_running(context.warehouse_id)
+        logger.info("Warehouse %s is running.", context.warehouse_id)
+```
+
+## Context object layering
+
+Behave's `context` has scoped layers. Data set at different levels has different lifetimes:
+
+| Set in | Lifetime | Example |
+|--------|----------|---------|
+| `before_all` | Entire run | `context.workspace`, `context.test_schema` |
+| `before_feature` | Current feature | `context.feature_data` |
+| `before_scenario` / steps | Current scenario | `context.query_result`, `context.scenario_cleanup_sql` |
+
+At the end of each scenario, the scenario layer is popped — anything set during steps is gone. Root-level data persists across everything.
+
+## Parallel execution isolation
+
+When using `behavex` for parallel execution, each worker needs its own schema. The template uses `BEHAVE_WORKER_ID` from the environment. Set it in the parallel runner config or wrapper script:
+
+```bash
+# Example wrapper for behavex
+export BEHAVE_WORKER_ID=$WORKER_INDEX
+behave "$@"
+```

--- a/.claude/skills/bdd-scaffold/test-suite/.gitignore
+++ b/.claude/skills/bdd-scaffold/test-suite/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+reports/
+*.pyc

--- a/.claude/skills/bdd-scaffold/test-suite/behave.ini
+++ b/.claude/skills/bdd-scaffold/test-suite/behave.ini
@@ -1,0 +1,13 @@
+[behave]
+default_format = pretty
+show_timings = true
+color = true
+default_tags = not @wip and not @skip
+logging_level = INFO
+stdout_capture = false
+log_capture = false
+paths = features/
+
+[behave.userdata]
+warehouse_id = auto
+catalog = main

--- a/.claude/skills/bdd-scaffold/test-suite/features/catalog/schema_operations.feature
+++ b/.claude/skills/bdd-scaffold/test-suite/features/catalog/schema_operations.feature
@@ -1,0 +1,38 @@
+@catalog @smoke
+Feature: Unity Catalog schema and table operations
+  As a data engineer
+  I want to verify Unity Catalog operations work correctly
+  So that I can manage my data assets with confidence
+
+  Background:
+    Given a Databricks workspace connection is established
+    And a test schema is provisioned
+
+  Scenario: Ephemeral test schema was created
+    Then the test schema should exist in Unity Catalog
+
+  Scenario: Create tables and list them
+    Given a managed table "table_alpha" exists
+    And a managed table "table_beta" exists
+    When I list tables in the test schema
+    Then the table list should include "table_alpha"
+    And the table list should include "table_beta"
+
+  Scenario: Table with data is queryable via SQL
+    Given a managed table "products" with data:
+      | product_id | name      | price |
+      | 1          | Widget    | 9.99  |
+      | 2          | Gadget    | 19.99 |
+      | 3          | Doohickey | 4.99  |
+    Then the managed table "products" should have 3 rows
+    When I execute a query on the test schema:
+      """
+      SELECT name, price FROM {schema}.products WHERE CAST(price AS DOUBLE) > 10.0
+      """
+    Then the query result should have 1 rows
+    And the first result column "name" should be "Gadget"
+
+  Scenario: Grant SELECT permission on a table
+    Given a managed table "grant_test" exists
+    When I grant SELECT on managed table "grant_test" to group "users"
+    Then the group "users" should have SELECT on managed table "grant_test"

--- a/.claude/skills/bdd-scaffold/test-suite/features/environment.py
+++ b/.claude/skills/bdd-scaffold/test-suite/features/environment.py
@@ -1,0 +1,131 @@
+"""Behave environment hooks — Databricks SDK integration.
+
+Tested against azure-east workspace.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+
+from behave.model import Feature, Scenario, Step
+from behave.runner import Context
+
+logger = logging.getLogger("behave.databricks")
+
+
+def before_all(context: Context) -> None:
+    """Initialize Databricks clients and create ephemeral test schema."""
+    from databricks.sdk import WorkspaceClient
+
+    # Use profile from env or default
+    profile = os.environ.get("DATABRICKS_CONFIG_PROFILE", "azure-east")
+    context.workspace = WorkspaceClient(profile=profile)
+
+    # Fix host URL — some profiles include ?o=<org_id> which breaks SDK API paths
+    if context.workspace.config.host and "?" in context.workspace.config.host:
+        clean_host = context.workspace.config.host.split("?")[0].rstrip("/")
+        context.workspace = WorkspaceClient(profile=profile, host=clean_host)
+
+    me = context.workspace.current_user.me()
+    context.current_user = me.user_name
+    logger.info("Authenticated as: %s", context.current_user)
+
+    # Warehouse — from -D userdata, env var, or auto-discover
+    userdata = context.config.userdata
+    wh_id = userdata.get("warehouse_id", "auto")
+    if wh_id == "auto":
+        wh_id = os.environ.get("DATABRICKS_WAREHOUSE_ID") or _discover_warehouse(
+            context.workspace
+        )
+    context.warehouse_id = wh_id
+    logger.info("Using warehouse: %s", context.warehouse_id)
+
+    # Catalog
+    context.test_catalog = userdata.get("catalog", "main")
+
+    # Create ephemeral schema
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    context.test_schema = f"{context.test_catalog}.behave_test_{ts}"
+
+    _execute_sql(context, f"CREATE SCHEMA IF NOT EXISTS {context.test_schema}")
+    logger.info("Created test schema: %s", context.test_schema)
+
+
+def after_all(context: Context) -> None:
+    """Drop ephemeral test schema."""
+    if hasattr(context, "test_schema"):
+        try:
+            _execute_sql(
+                context, f"DROP SCHEMA IF EXISTS {context.test_schema} CASCADE"
+            )
+            logger.info("Dropped test schema: %s", context.test_schema)
+        except Exception as e:
+            logger.warning("Failed to drop test schema %s: %s", context.test_schema, e)
+
+
+def before_feature(context: Context, feature: Feature) -> None:
+    logger.info("▶ Feature: %s", feature.name)
+    if "skip" in feature.tags:
+        feature.skip("Marked with @skip")
+
+
+def after_feature(context: Context, feature: Feature) -> None:
+    logger.info("◀ Feature: %s [%s]", feature.name, feature.status)
+
+
+def before_scenario(context: Context, scenario: Scenario) -> None:
+    logger.info("  ▶ Scenario: %s", scenario.name)
+    if "wip" in scenario.tags:
+        scenario.skip("Work in progress")
+        return
+    context.scenario_cleanup_sql = []
+
+
+def after_scenario(context: Context, scenario: Scenario) -> None:
+    for sql in getattr(context, "scenario_cleanup_sql", []):
+        try:
+            _execute_sql(context, sql)
+        except Exception as e:
+            logger.warning("Cleanup SQL failed: %s — %s", sql, e)
+    if scenario.status == "failed":
+        logger.error("  ✗ FAILED: %s", scenario.name)
+
+
+def before_step(context: Context, step: Step) -> None:
+    context._step_start = datetime.now()
+
+
+def after_step(context: Context, step: Step) -> None:
+    elapsed = (datetime.now() - context._step_start).total_seconds()
+    if elapsed > 10:
+        logger.warning("    Slow step (%.1fs): %s %s", elapsed, step.keyword, step.name)
+    if step.status == "failed":
+        logger.error(
+            "    ✗ %s %s\n      %s", step.keyword, step.name, step.error_message
+        )
+
+
+# ─── Helpers ────────────────────────────────────────────────────
+
+
+def _execute_sql(context: Context, sql: str) -> object:
+    """Execute a SQL statement via the Statement Execution API."""
+    return context.workspace.statement_execution.execute_statement(
+        warehouse_id=context.warehouse_id,
+        statement=sql,
+        wait_timeout="30s",
+    )
+
+
+def _discover_warehouse(workspace) -> str:
+    """Find the first available SQL warehouse."""
+    from databricks.sdk.service.sql import State
+
+    warehouses = list(workspace.warehouses.list())
+    for wh in warehouses:
+        if wh.state == State.RUNNING:
+            return wh.id
+    if warehouses:
+        return warehouses[0].id
+    raise RuntimeError("No SQL warehouses found")

--- a/.claude/skills/bdd-scaffold/test-suite/features/sql/data_operations.feature
+++ b/.claude/skills/bdd-scaffold/test-suite/features/sql/data_operations.feature
@@ -1,0 +1,48 @@
+@sql @smoke
+Feature: SQL data operations via Databricks
+  As a data engineer
+  I want to verify SQL operations work correctly against the warehouse
+  So that I can trust my data transformations
+
+  Background:
+    Given a Databricks workspace connection is established
+    And a test schema is provisioned
+
+  Scenario: Create a table and verify it exists
+    Given a managed table "smoke_test" exists
+    Then the managed table "smoke_test" should exist
+
+  Scenario: Insert and count rows
+    Given a managed table "customers" with data:
+      | customer_id | name    | email               |
+      | 1           | Alice   | alice@example.com   |
+      | 2           | Bob     | bob@example.com     |
+      | 3           | Charlie | charlie@example.com |
+    Then the managed table "customers" should have 3 rows
+
+  Scenario: Aggregate query returns correct results
+    Given a managed table "orders" with data:
+      | order_id | customer_id | amount |
+      | 101      | 1           | 50     |
+      | 102      | 1           | 75     |
+      | 103      | 2           | 100    |
+    When I execute a query on the test schema:
+      """
+      SELECT customer_id, COUNT(*) as order_count
+      FROM {schema}.orders
+      GROUP BY customer_id
+      HAVING COUNT(*) > 1
+      """
+    Then the query result should have 1 rows
+    And the first result column "customer_id" should be "1"
+
+  Scenario: Query with no matching rows returns zero
+    Given a managed table "statuses" with data:
+      | id | status |
+      | 1  | active |
+      | 2  | active |
+    When I execute a query on the test schema:
+      """
+      SELECT * FROM {schema}.statuses WHERE status = 'inactive'
+      """
+    Then the query result should have 0 rows

--- a/.claude/skills/bdd-scaffold/test-suite/features/steps/catalog_steps.py
+++ b/.claude/skills/bdd-scaffold/test-suite/features/steps/catalog_steps.py
@@ -1,0 +1,84 @@
+"""Step definitions for Unity Catalog operations.
+
+Table names in Gherkin are short ("customers").
+Schema resolution happens in _fqn() via context.test_schema.
+"""
+from __future__ import annotations
+
+from behave import when, then
+from behave.runner import Context
+
+
+@when("I list tables in the test schema")
+def step_list_tables(context: Context) -> None:
+    catalog, schema = context.test_schema.split(".", 1)
+    context.table_list = list(
+        context.workspace.tables.list(catalog_name=catalog, schema_name=schema)
+    )
+
+
+@then("the table list should include {table_count:d} tables")
+def step_table_count(context: Context, table_count: int) -> None:
+    actual = len(context.table_list)
+    assert actual == table_count, (
+        f"Expected {table_count} tables, got {actual}: "
+        f"{[t.name for t in context.table_list]}"
+    )
+
+
+@then('the table list should include "{table_name}"')
+def step_table_in_list(context: Context, table_name: str) -> None:
+    names = [t.name for t in context.table_list]
+    assert table_name in names, f"Table '{table_name}' not in list: {names}"
+
+
+@when('I grant {privilege} on managed table "{table_name}" to group "{group}"')
+def step_grant_privilege(
+    context: Context, privilege: str, table_name: str, group: str
+) -> None:
+    """Grant privilege using SQL — more stable across SDK versions than the grants API."""
+    from databricks.sdk.service.sql import StatementState
+
+    fqn = f"{context.test_schema}.{table_name}"
+    result = context.workspace.statement_execution.execute_statement(
+        warehouse_id=context.warehouse_id,
+        statement=f"GRANT {privilege} ON TABLE {fqn} TO `{group}`",
+        wait_timeout="30s",
+    )
+    assert result.status.state == StatementState.SUCCEEDED, (
+        f"GRANT failed: {result.status.error}"
+    )
+
+
+@then('the group "{group}" should have {privilege} on managed table "{table_name}"')
+def step_verify_permission(
+    context: Context, group: str, privilege: str, table_name: str
+) -> None:
+    """Verify privilege using SHOW GRANTS — stable across SDK versions."""
+    from databricks.sdk.service.sql import StatementState
+
+    fqn = f"{context.test_schema}.{table_name}"
+    result = context.workspace.statement_execution.execute_statement(
+        warehouse_id=context.warehouse_id,
+        statement=f"SHOW GRANTS ON TABLE {fqn}",
+        wait_timeout="30s",
+    )
+    assert result.status.state == StatementState.SUCCEEDED, (
+        f"SHOW GRANTS failed: {result.status.error}"
+    )
+    # Parse result: columns are Principal, ActionType, ObjectType, ObjectKey (PascalCase)
+    rows = result.result.data_array or []
+    columns = [c.name for c in result.manifest.schema.columns]
+    # Handle case variation — normalize to lowercase for lookup
+    col_lower = [c.lower() for c in columns]
+    principal_idx = col_lower.index("principal")
+    action_idx = col_lower.index("actiontype")
+
+    found = any(
+        row[principal_idx] == group and row[action_idx] == privilege
+        for row in rows
+    )
+    assert found, (
+        f"Expected {group} to have {privilege} on {fqn}. "
+        f"Grants found: {[(r[principal_idx], r[action_idx]) for r in rows]}"
+    )

--- a/.claude/skills/bdd-scaffold/test-suite/features/steps/common_steps.py
+++ b/.claude/skills/bdd-scaffold/test-suite/features/steps/common_steps.py
@@ -1,0 +1,130 @@
+"""Shared step definitions for Databricks BDD tests.
+
+Design principle: Gherkin uses short table names ("customers").
+Step definitions prepend context.test_schema internally.
+This avoids {curly_brace} conflicts with Behave's parse library.
+"""
+from __future__ import annotations
+
+from behave import given, when, then, step
+from behave.runner import Context
+from databricks.sdk.service.sql import StatementState
+
+
+# ─── Connection and setup ────────────────────────────────────────
+
+
+@given("a Databricks workspace connection is established")
+def step_workspace_connection(context: Context) -> None:
+    assert hasattr(context, "workspace"), "No workspace client — check environment.py"
+    assert hasattr(context, "warehouse_id"), "No warehouse_id — check environment.py"
+
+
+@given("a test schema is provisioned")
+def step_test_schema(context: Context) -> None:
+    assert hasattr(context, "test_schema"), "No test_schema — check environment.py"
+
+
+# ─── Table creation ──────────────────────────────────────────────
+
+
+@given('a managed table "{table_name}" exists')
+def step_ensure_table(context: Context, table_name: str) -> None:
+    fqn = _fqn(context, table_name)
+    _sql(context, f"CREATE TABLE IF NOT EXISTS {fqn} (id BIGINT)")
+    context.scenario_cleanup_sql.append(f"DROP TABLE IF EXISTS {fqn}")
+
+
+@given('a managed table "{table_name}" with data:')
+def step_create_with_data(context: Context, table_name: str) -> None:
+    fqn = _fqn(context, table_name)
+    headers = context.table.headings
+    rows = context.table.rows
+
+    col_defs = ", ".join(f"`{h}` STRING" for h in headers)
+    _sql(context, f"CREATE OR REPLACE TABLE {fqn} ({col_defs})")
+    context.scenario_cleanup_sql.append(f"DROP TABLE IF EXISTS {fqn}")
+
+    for row in rows:
+        values = ", ".join(f"'{cell}'" for cell in row)
+        _sql(context, f"INSERT INTO {fqn} VALUES ({values})")
+
+
+# ─── SQL execution ───────────────────────────────────────────────
+
+
+@when("I execute a query on the test schema:")
+def step_execute_sql(context: Context) -> None:
+    """Execute SQL from docstring. Use {schema} as placeholder for test schema."""
+    sql = context.text.replace("{schema}", context.test_schema)
+    context.query_result = _sql(context, sql)
+
+
+# ─── Table assertions ────────────────────────────────────────────
+
+
+@then('the managed table "{table_name}" should exist')
+def step_table_exists(context: Context, table_name: str) -> None:
+    fqn = _fqn(context, table_name)
+    try:
+        context.workspace.tables.get(fqn)
+    except Exception as e:
+        raise AssertionError(f"Table {fqn} does not exist: {e}")
+
+
+@then('the managed table "{table_name}" should have {expected:d} rows')
+def step_row_count(context: Context, table_name: str, expected: int) -> None:
+    fqn = _fqn(context, table_name)
+    result = _sql(context, f"SELECT COUNT(*) AS cnt FROM {fqn}")
+    actual = int(result.result.data_array[0][0])
+    assert actual == expected, f"Expected {expected} rows in {table_name}, got {actual}"
+
+
+@then("the test schema should exist in Unity Catalog")
+def step_schema_exists(context: Context) -> None:
+    try:
+        context.workspace.schemas.get(context.test_schema)
+    except Exception as e:
+        raise AssertionError(f"Schema {context.test_schema} does not exist: {e}")
+
+
+# ─── Query result assertions ────────────────────────────────────
+
+
+@then("the query result should have {expected:d} rows")
+def step_result_row_count(context: Context, expected: int) -> None:
+    rows = context.query_result.result.data_array or []
+    actual = len(rows)
+    assert actual == expected, f"Expected {expected} result rows, got {actual}"
+
+
+@then('the first result column "{col}" should be "{value}"')
+def step_first_result_value(context: Context, col: str, value: str) -> None:
+    result = context.query_result
+    columns = [c.name for c in result.manifest.schema.columns]
+    assert col in columns, f"Column '{col}' not in result: {columns}"
+    col_idx = columns.index(col)
+    actual = result.result.data_array[0][col_idx]
+    assert str(actual) == value, f"Expected {col}='{value}', got '{actual}'"
+
+
+# ─── Helpers ─────────────────────────────────────────────────────
+
+
+def _fqn(context: Context, table_name: str) -> str:
+    """Build fully-qualified table name from short name."""
+    return f"{context.test_schema}.{table_name}"
+
+
+def _sql(context: Context, sql: str):
+    """Execute SQL and assert success."""
+    result = context.workspace.statement_execution.execute_statement(
+        warehouse_id=context.warehouse_id,
+        statement=sql,
+        wait_timeout="30s",
+    )
+    assert result.status.state == StatementState.SUCCEEDED, (
+        f"SQL failed ({result.status.state}): {result.status.error}\n"
+        f"Statement: {sql[:200]}"
+    )
+    return result

--- a/.claude/skills/bdd-scaffold/test-suite/pyproject.toml
+++ b/.claude/skills/bdd-scaffold/test-suite/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "bdd-test-suite"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "behave>=1.2.6",
+    "databricks-sdk>=0.40.0",
+    "httpx>=0.27.0",
+]
+
+[tool.behave]
+default_format = "pretty"
+show_timings = true
+default_tags = ["not @wip and not @skip"]
+logging_level = "INFO"
+
+[tool.behave.userdata]
+warehouse_id = "auto"
+catalog = "main"

--- a/.claude/skills/bdd-steps/SKILL.md
+++ b/.claude/skills/bdd-steps/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: bdd-steps
+description: "This skill should be used when the user asks to \"write step definitions\", \"implement BDD steps\", \"generate step code\", \"create Behave steps\", \"implement Given When Then\", \"write Python steps for Gherkin\", \"step definitions for Databricks\", or needs to create Python step implementations for existing Gherkin feature files."
+user-invocable: true
+---
+
+# BDD Steps — Python Step Definition Generation
+
+Generate Python step definitions for Behave that implement Gherkin steps using the Databricks SDK. Read existing `.feature` files, identify undefined steps, and produce well-typed implementations.
+
+## When to use
+
+- Implementing step definitions for new or existing feature files
+- Adding Databricks SDK calls to step implementations
+- Refactoring step definitions for reusability across features
+
+## Process
+
+### 1. Identify undefined steps
+
+Read the target feature files, then run a dry-run to find undefined steps:
+
+```bash
+uv run behave --dry-run features/<target>.feature 2>&1
+```
+
+Behave prints suggested snippets for each undefined step. Use these as the starting point.
+
+### 2. Write step definitions
+
+Place step files in `features/steps/` organized by domain:
+
+| File | Domain | Key SDK imports |
+|------|--------|----------------|
+| `common_steps.py` | Shared utilities | `WorkspaceClient`, `StatementState` |
+| `catalog_steps.py` | Unity Catalog | `catalog.PermissionsChange`, `catalog.Privilege`, `catalog.SecurableType` |
+| `pipeline_steps.py` | Lakeflow SDP | `pipelines.PipelineStateInfo` |
+| `job_steps.py` | Jobs/Notebooks | `jobs.SubmitTask`, `jobs.NotebookTask`, `jobs.RunLifeCycleState` |
+| `app_steps.py` | Databricks Apps | `httpx.Client` for HTTP assertions |
+| `sql_steps.py` | SQL/Data quality | `sql.StatementState`, `sql.Disposition` |
+
+**Step definition structure:**
+
+```python
+from __future__ import annotations
+
+from behave import given, when, then
+from behave.runner import Context
+
+
+@given('a descriptive step pattern with "{parameter}"')
+def step_impl(context: Context, parameter: str) -> None:
+    """Docstring explaining what this step does."""
+    # Implementation using context.workspace (set in environment.py)
+    ...
+```
+
+Refer to `references/step-library.md` for a comprehensive library of reusable Databricks step definitions covering:
+- Workspace connection and SQL execution
+- Table/schema existence and row count assertions
+- Grant and permission verification
+- Pipeline triggering and status polling
+- Job submission and completion waiting
+- HTTP endpoint testing with SSO header simulation
+
+### 3. Step writing principles
+
+**Use `context` for state passing.** Store results in `context` attributes so downstream `Then` steps can assert on them:
+
+```python
+@when('I execute a query on "{table_name}"')
+def step_execute(context: Context, table_name: str) -> None:
+    context.query_result = context.workspace.statement_execution.execute_statement(...)
+
+@then('the result should have {count:d} rows')
+def step_check_rows(context: Context, count: int) -> None:
+    actual = len(context.query_result.result.data_array or [])
+    assert actual == count, f"Expected {count}, got {actual}"
+```
+
+**Type all parameters.** Use Behave's parse types (`{name:d}` for int, `{name:f}` for float) or register custom types.
+
+**Assertion messages must be diagnostic.** Always include expected vs. actual values:
+
+```python
+assert actual == expected, f"Expected {expected}, got {actual}"
+```
+
+**Substitute `{test_schema}` references.** Feature files may use `{test_schema}` as a placeholder. Step definitions should resolve it from `context.test_schema`:
+
+```python
+table_fqn = table_name.replace("{test_schema}", context.test_schema)
+```
+
+**Poll with timeout for async operations.** Jobs, pipelines, and app deployments need polling loops with configurable timeouts.
+
+### 4. Validate steps compile
+
+After writing, verify all steps resolve:
+
+```bash
+uv run behave --dry-run
+```
+
+Zero undefined steps = ready to run.
+
+## Additional resources
+
+- **`references/step-library.md`** — Complete reusable step definition library for all Databricks domains

--- a/.claude/skills/bdd-steps/references/step-library.md
+++ b/.claude/skills/bdd-steps/references/step-library.md
@@ -1,0 +1,660 @@
+# Reusable Step Definition Library
+
+Complete library of Databricks step definitions for Behave. Organized by domain. Copy relevant sections into `features/steps/` files.
+
+**Proven patterns used throughout:**
+
+- Step patterns use **short names** (e.g., `"{table_name}"`), never `{test_schema}.table` in the pattern
+- Step code builds FQN internally: `fqn = f"{context.test_schema}.{table_name}"`
+- SQL in docstrings uses `{schema}` placeholder, replaced via `context.text.replace("{schema}", context.test_schema)`
+- Steps with data tables have a **trailing colon** in the decorator: `@given('... with data:')`
+- Grants use **SQL**, not the SDK grants API (which breaks on recent SDK versions)
+- Integer parameters use Behave's built-in `{count:d}` format, not custom type parsers
+
+---
+
+## Common Steps (`common_steps.py`)
+
+Always include these. They provide workspace connection, SQL execution, and basic assertions.
+
+```python
+"""Shared step definitions for Databricks BDD tests."""
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from behave import given, then, step
+from behave.runner import Context
+from databricks.sdk.service.sql import StatementState
+
+
+# ─── Connection and setup steps ─────────────────────────────────
+
+@given("a Databricks workspace connection is established")
+def step_workspace_connection(context: Context) -> None:
+    """Initialize workspace client. Usually handled by environment.py."""
+    if not hasattr(context, "workspace"):
+        from databricks.sdk import WorkspaceClient
+        context.workspace = WorkspaceClient()
+        me = context.workspace.current_user.me()
+        context.current_user = me.user_name
+
+
+@given("a test schema is provisioned")
+def step_test_schema(context: Context) -> None:
+    """Verify test schema exists. Usually handled by environment.py."""
+    assert hasattr(context, "test_schema"), (
+        "No test_schema on context — check environment.py before_all"
+    )
+
+
+# ─── SQL execution steps ────────────────────────────────────────
+
+@step("I execute the following SQL")
+def step_execute_sql_docstring(context: Context) -> None:
+    """Execute SQL from a docstring (triple-quoted text in feature file).
+
+    In feature files, use {schema} as the placeholder:
+        When I execute the following SQL
+            \"\"\"
+            SELECT * FROM {schema}.customers
+            \"\"\"
+    """
+    sql = context.text.replace("{schema}", context.test_schema)
+    context.query_result = _execute_sql(context, sql)
+
+
+@step('I execute SQL "{sql}"')
+def step_execute_sql_inline(context: Context, sql: str) -> None:
+    """Execute inline SQL. The {schema} placeholder is replaced automatically."""
+    sql = sql.replace("{schema}", context.test_schema)
+    context.query_result = _execute_sql(context, sql)
+
+
+# ─── Table existence and row count assertions ───────────────────
+
+@then('the table "{table_name}" should exist')
+def step_table_exists(context: Context, table_name: str) -> None:
+    fqn = f"{context.test_schema}.{table_name}"
+    try:
+        context.workspace.tables.get(fqn)
+    except Exception as e:
+        raise AssertionError(f"Table {fqn} does not exist: {e}")
+
+
+@then('the streaming table "{table_name}" should exist')
+def step_streaming_table_exists(context: Context, table_name: str) -> None:
+    fqn = f"{context.test_schema}.{table_name}"
+    try:
+        info = context.workspace.tables.get(fqn)
+        assert info.table_type is not None, f"{fqn} exists but has no table_type"
+    except Exception as e:
+        raise AssertionError(f"Streaming table {fqn} does not exist: {e}")
+
+
+@then('the materialized view "{table_name}" should exist')
+def step_mv_exists(context: Context, table_name: str) -> None:
+    fqn = f"{context.test_schema}.{table_name}"
+    try:
+        context.workspace.tables.get(fqn)
+    except Exception as e:
+        raise AssertionError(f"Materialized view {fqn} does not exist: {e}")
+
+
+@then('the table "{table_name}" should have {expected:d} rows')
+def step_exact_row_count(context: Context, table_name: str, expected: int) -> None:
+    actual = _count_rows(context, table_name)
+    assert actual == expected, f"Expected {expected} rows in {table_name}, got {actual}"
+
+
+@then('the table "{table_name}" should have more than {expected:d} rows')
+def step_min_row_count(context: Context, table_name: str, expected: int) -> None:
+    actual = _count_rows(context, table_name)
+    assert actual > expected, f"Expected more than {expected} rows in {table_name}, got {actual}"
+
+
+@then('the table "{table_name}" should have 0 rows')
+def step_empty_table(context: Context, table_name: str) -> None:
+    actual = _count_rows(context, table_name)
+    assert actual == 0, f"Expected 0 rows in {table_name}, got {actual}"
+
+
+# ─── Query result assertions ────────────────────────────────────
+
+@then("the result should have {expected:d} rows")
+def step_result_row_count(context: Context, expected: int) -> None:
+    rows = context.query_result.result.data_array or []
+    actual = len(rows)
+    assert actual == expected, f"Expected {expected} rows, got {actual}"
+
+
+@then("the result should have more than {expected:d} rows")
+def step_result_min_rows(context: Context, expected: int) -> None:
+    rows = context.query_result.result.data_array or []
+    actual = len(rows)
+    assert actual > expected, f"Expected more than {expected} rows, got {actual}"
+
+
+@then('the first row column "{col}" should be "{value}"')
+def step_first_row_value(context: Context, col: str, value: str) -> None:
+    result = context.query_result
+    columns = [c.name for c in result.manifest.schema.columns]
+    col_idx = columns.index(col)
+    actual = result.result.data_array[0][col_idx]
+    assert str(actual) == value, f"Expected {col}={value}, got {actual}"
+
+
+# ─── Data setup steps ───────────────────────────────────────────
+
+@given('the table "{table_name}" has been loaded')
+def step_table_loaded(context: Context, table_name: str) -> None:
+    """Assert table exists and is not empty."""
+    fqn = f"{context.test_schema}.{table_name}"
+    count = _count_rows(context, table_name)
+    assert count > 0, f"Table {fqn} exists but is empty"
+
+
+@given('a managed table "{table_name}" exists')
+def step_ensure_table_exists(context: Context, table_name: str) -> None:
+    fqn = f"{context.test_schema}.{table_name}"
+    try:
+        context.workspace.tables.get(fqn)
+    except Exception:
+        # Create a minimal table
+        _execute_sql(context, f"CREATE TABLE IF NOT EXISTS {fqn} (id BIGINT)")
+        context.scenario_cleanup_sql.append(f"DROP TABLE IF EXISTS {fqn}")
+
+
+@given('a managed table "{table_name}" with data:')
+def step_create_table_with_data(context: Context, table_name: str) -> None:
+    """Create a table and populate from the Gherkin data table.
+
+    The trailing colon in the decorator is required — Behave matches it
+    as part of the step text when a data table follows.
+
+    Example feature file usage:
+        Given a managed table "customers" with data:
+            | id | name    | region |
+            | 1  | Acme    | APAC   |
+            | 2  | Contoso | EMEA   |
+    """
+    fqn = f"{context.test_schema}.{table_name}"
+    headers = context.table.headings
+    rows = context.table.rows
+
+    # Infer types (simple heuristic — all STRING)
+    col_defs = ", ".join(f"{h} STRING" for h in headers)
+    _execute_sql(context, f"CREATE OR REPLACE TABLE {fqn} ({col_defs})")
+    context.scenario_cleanup_sql.append(f"DROP TABLE IF EXISTS {fqn}")
+
+    # Insert rows
+    for row in rows:
+        values = ", ".join(f"'{cell}'" for cell in row)
+        _execute_sql(context, f"INSERT INTO {fqn} VALUES ({values})")
+
+
+# ─── Helpers ────────────────────────────────────────────────────
+
+def _execute_sql(context: Context, sql: str):
+    """Execute SQL and return result."""
+    result = context.workspace.statement_execution.execute_statement(
+        warehouse_id=context.warehouse_id,
+        statement=sql,
+        wait_timeout="30s",
+    )
+    assert result.status.state == StatementState.SUCCEEDED, (
+        f"SQL failed: {result.status.error}\nStatement: {sql[:200]}"
+    )
+    return result
+
+
+def _count_rows(context: Context, table_name: str) -> int:
+    """Count rows in a table."""
+    fqn = f"{context.test_schema}.{table_name}"
+    result = _execute_sql(context, f"SELECT COUNT(*) AS cnt FROM {fqn}")
+    return int(result.result.data_array[0][0])
+```
+
+---
+
+## Catalog Steps (`catalog_steps.py`)
+
+Uses SQL for grants instead of the SDK grants API. The SDK's `grants.update(securable_type=SecurableType.TABLE, ...)` fails with `SECURABLETYPE.TABLE is not a valid securable type` on recent SDK versions.
+
+```python
+"""Step definitions for Unity Catalog permissions and security.
+
+Uses SQL for all grant operations. The SDK grants API is unreliable —
+SecurableType.TABLE fails on recent databricks-sdk versions.
+"""
+from __future__ import annotations
+
+from behave import when, then
+from behave.runner import Context
+from databricks.sdk.service.sql import StatementState
+
+
+@when('I grant {privilege} on table "{table_name}" to group "{group}"')
+def step_grant(context: Context, privilege: str, table_name: str, group: str) -> None:
+    """Grant a privilege on a table using SQL.
+
+    Example feature file usage:
+        When I grant SELECT on table "customers" to group "analysts"
+    """
+    fqn = f"{context.test_schema}.{table_name}"
+    _execute_sql(context, f"GRANT {privilege} ON TABLE {fqn} TO `{group}`")
+
+
+@when('I revoke {privilege} on table "{table_name}" from group "{group}"')
+def step_revoke(context: Context, privilege: str, table_name: str, group: str) -> None:
+    """Revoke a privilege on a table using SQL."""
+    fqn = f"{context.test_schema}.{table_name}"
+    _execute_sql(context, f"REVOKE {privilege} ON TABLE {fqn} FROM `{group}`")
+
+
+@then('the group "{group}" should have {privilege} permission on "{table_name}"')
+def step_verify_grant(
+    context: Context, group: str, privilege: str, table_name: str
+) -> None:
+    """Verify a grant exists using SHOW GRANTS.
+
+    SHOW GRANTS returns PascalCase columns: Principal, ActionType, ObjectType, ObjectKey.
+    """
+    fqn = f"{context.test_schema}.{table_name}"
+    result = _execute_sql(context, f"SHOW GRANTS ON TABLE {fqn}")
+    columns = [c.name for c in result.manifest.schema.columns]
+    principal_idx = columns.index("Principal")
+    action_idx = columns.index("ActionType")
+
+    found_privs = []
+    for row in result.result.data_array or []:
+        if row[principal_idx] == group:
+            found_privs.append(row[action_idx])
+
+    assert privilege in found_privs, (
+        f"Expected {group} to have {privilege} on {fqn}, "
+        f"found: {found_privs}"
+    )
+
+
+@then('the group "{group}" should not have {privilege} permission on "{table_name}"')
+def step_verify_no_grant(
+    context: Context, group: str, privilege: str, table_name: str
+) -> None:
+    """Verify a grant does NOT exist using SHOW GRANTS."""
+    fqn = f"{context.test_schema}.{table_name}"
+    result = _execute_sql(context, f"SHOW GRANTS ON TABLE {fqn}")
+    columns = [c.name for c in result.manifest.schema.columns]
+    principal_idx = columns.index("Principal")
+    action_idx = columns.index("ActionType")
+
+    found_privs = []
+    for row in result.result.data_array or []:
+        if row[principal_idx] == group:
+            found_privs.append(row[action_idx])
+
+    assert privilege not in found_privs, (
+        f"Expected {group} NOT to have {privilege} on {fqn}, "
+        f"but found: {found_privs}"
+    )
+
+
+def _execute_sql(context: Context, sql: str):
+    """Execute SQL and return result."""
+    result = context.workspace.statement_execution.execute_statement(
+        warehouse_id=context.warehouse_id,
+        statement=sql,
+        wait_timeout="30s",
+    )
+    assert result.status.state == StatementState.SUCCEEDED, (
+        f"SQL failed: {result.status.error}\nStatement: {sql[:200]}"
+    )
+    return result
+```
+
+---
+
+## Pipeline Steps (`pipeline_steps.py`)
+
+```python
+"""Step definitions for Lakeflow Spark Declarative Pipelines."""
+from __future__ import annotations
+
+import time
+
+from behave import given, when, then
+from behave.runner import Context
+
+
+@given('a pipeline "{name}" exists targeting "{schema}"')
+def step_pipeline_exists(context: Context, name: str, schema: str) -> None:
+    pipelines = list(
+        context.workspace.pipelines.list_pipelines(filter=f'name LIKE "{name}"')
+    )
+    if pipelines:
+        context.pipeline_id = pipelines[0].pipeline_id
+    else:
+        result = context.workspace.pipelines.create(
+            name=name,
+            target=schema,
+            catalog=context.test_catalog,
+            channel="CURRENT",
+        )
+        context.pipeline_id = result.pipeline_id
+        context.scenario_cleanup_sql.append(None)  # Mark for pipeline cleanup
+
+
+@given('the pipeline "{name}" has completed a full refresh')
+def step_pipeline_refreshed(context: Context, name: str) -> None:
+    """Ensure pipeline exists and has been refreshed at least once."""
+    pipelines = list(
+        context.workspace.pipelines.list_pipelines(filter=f'name LIKE "{name}"')
+    )
+    assert pipelines, f"Pipeline '{name}' not found"
+    context.pipeline_id = pipelines[0].pipeline_id
+    # Check latest update status
+    detail = context.workspace.pipelines.get(context.pipeline_id)
+    assert detail.latest_updates, f"Pipeline '{name}' has never been run"
+
+
+@when("I trigger a full refresh of the pipeline")
+def step_full_refresh(context: Context) -> None:
+    response = context.workspace.pipelines.start_update(
+        pipeline_id=context.pipeline_id,
+        full_refresh=True,
+    )
+    context.update_id = response.update_id
+
+
+@when("I trigger an incremental refresh of the pipeline")
+def step_incremental_refresh(context: Context) -> None:
+    response = context.workspace.pipelines.start_update(
+        pipeline_id=context.pipeline_id,
+        full_refresh=False,
+    )
+    context.update_id = response.update_id
+
+
+@then("the pipeline update should succeed within {timeout:d} seconds")
+def step_pipeline_success(context: Context, timeout: int) -> None:
+    _wait_for_pipeline(context, timeout, expect_success=True)
+
+
+@then("the pipeline update should fail")
+def step_pipeline_fail(context: Context) -> None:
+    _wait_for_pipeline(context, timeout=300, expect_success=False)
+
+
+@then('the pipeline error should mention {keyword}')
+def step_pipeline_error_contains(context: Context, keyword: str) -> None:
+    events = list(context.workspace.pipelines.list_pipeline_events(
+        pipeline_id=context.pipeline_id,
+        max_results=10,
+    ))
+    error_messages = " ".join(
+        str(e.message) for e in events if e.level == "ERROR"
+    )
+    assert keyword.lower() in error_messages.lower(), (
+        f"Expected pipeline error to mention '{keyword}', "
+        f"but errors were: {error_messages[:500]}"
+    )
+
+
+def _wait_for_pipeline(
+    context: Context, timeout: int, expect_success: bool
+) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        update = context.workspace.pipelines.get_update(
+            pipeline_id=context.pipeline_id,
+            update_id=context.update_id,
+        )
+        state = update.update.state
+        if state in ("COMPLETED",):
+            if expect_success:
+                return
+            raise AssertionError("Expected pipeline to fail, but it succeeded")
+        if state in ("FAILED", "CANCELED"):
+            if not expect_success:
+                return
+            raise AssertionError(
+                f"Pipeline update {state}. Check update {context.update_id}"
+            )
+        time.sleep(15)
+    raise TimeoutError(f"Pipeline did not complete within {timeout}s")
+```
+
+---
+
+## Job Steps (`job_steps.py`)
+
+```python
+"""Step definitions for Databricks Jobs and notebook runs."""
+from __future__ import annotations
+
+import time
+
+from behave import when, then
+from behave.runner import Context
+from databricks.sdk.service.jobs import (
+    NotebookTask,
+    RunLifeCycleState,
+    SubmitTask,
+)
+
+
+@when('I run the notebook "{path}" with parameters:')
+def step_run_notebook(context: Context, path: str) -> None:
+    """Run a notebook with parameters from a Gherkin data table.
+
+    The trailing colon is required when a data table follows.
+
+    Example feature file usage:
+        When I run the notebook "/Workspace/tests/etl" with parameters:
+            | key    | value       |
+            | schema | my_schema   |
+            | mode   | full        |
+    """
+    params = {}
+    for row in context.table:
+        value = row["value"].replace("{schema}", context.test_schema)
+        params[row["key"]] = value
+
+    run = context.workspace.jobs.submit(
+        run_name=f"behave-{context.scenario.name[:50]}",
+        tasks=[
+            SubmitTask(
+                task_key="main",
+                notebook_task=NotebookTask(
+                    notebook_path=path,
+                    base_parameters=params,
+                ),
+            )
+        ],
+    )
+    context.run_id = run.response.run_id
+
+
+@then('the job should complete with status "{expected}" within {timeout:d} seconds')
+def step_job_status(context: Context, expected: str, timeout: int) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        run = context.workspace.jobs.get_run(context.run_id)
+        state = run.state
+        if state.life_cycle_state in (
+            RunLifeCycleState.TERMINATED,
+            RunLifeCycleState.INTERNAL_ERROR,
+            RunLifeCycleState.SKIPPED,
+        ):
+            break
+        time.sleep(10)
+    else:
+        raise TimeoutError(f"Run {context.run_id} did not complete within {timeout}s")
+
+    actual = state.result_state.value if state.result_state else "UNKNOWN"
+    assert actual == expected, (
+        f"Expected {expected}, got {actual}. Message: {state.state_message}"
+    )
+```
+
+---
+
+## App Steps (`app_steps.py`)
+
+```python
+"""Step definitions for Databricks Apps (FastAPI) testing."""
+from __future__ import annotations
+
+import subprocess
+import os
+
+import httpx
+from behave import given, when, then
+from behave.runner import Context
+
+
+@given('the app is running at "{base_url}"')
+def step_app_running(context: Context, base_url: str) -> None:
+    context.app_client = httpx.Client(base_url=base_url, timeout=10)
+
+
+@given('the test user is "{email}"')
+def step_test_user(context: Context, email: str) -> None:
+    context.auth_headers = {
+        "X-Forwarded-Email": email,
+        "X-Forwarded-User": email.split("@")[0],
+    }
+
+
+@when('I GET "{path}"')
+def step_get(context: Context, path: str) -> None:
+    context.response = context.app_client.get(path)
+
+
+@when('I GET "{path}" with auth headers')
+def step_get_auth(context: Context, path: str) -> None:
+    context.response = context.app_client.get(path, headers=context.auth_headers)
+
+
+@when('I GET "{path}" without auth headers')
+def step_get_no_auth(context: Context, path: str) -> None:
+    context.response = context.app_client.get(path)
+
+
+@when('I POST "{path}" with auth headers and body')
+def step_post_auth(context: Context, path: str) -> None:
+    """POST with JSON body from a docstring.
+
+    Example feature file usage:
+        When I POST "/api/items" with auth headers and body
+            \"\"\"
+            {"name": "test-item", "value": 42}
+            \"\"\"
+    """
+    import json
+    body = json.loads(context.text)
+    context.response = context.app_client.post(
+        path, json=body, headers=context.auth_headers,
+    )
+
+
+@then("the response status should be {code:d}")
+def step_status_code(context: Context, code: int) -> None:
+    assert context.response.status_code == code, (
+        f"Expected {code}, got {context.response.status_code}: "
+        f"{context.response.text[:200]}"
+    )
+
+
+@then('the response JSON should contain "{key}" with value "{value}"')
+def step_json_value(context: Context, key: str, value: str) -> None:
+    data = context.response.json()
+    assert key in data, f"Key '{key}' not in response: {list(data.keys())}"
+    assert str(data[key]) == value, f"Expected {key}='{value}', got '{data[key]}'"
+
+
+@then("the response should be a JSON list")
+def step_json_list(context: Context) -> None:
+    data = context.response.json()
+    assert isinstance(data, list), f"Expected list, got {type(data).__name__}"
+
+
+# ─── Deployment steps ────────────────────────────────────────────
+
+@when('I deploy using Asset Bundles with target "{target}"')
+def step_deploy_bundle(context: Context, target: str) -> None:
+    result = subprocess.run(
+        ["databricks", "bundle", "deploy", "--target", target],
+        capture_output=True,
+        text=True,
+        env={**dict(os.environ), "DATABRICKS_BUNDLE_ENGINE": "direct"},
+        timeout=300,
+    )
+    context.deploy_result = result
+
+
+@then("the deployment should succeed")
+def step_deploy_success(context: Context) -> None:
+    r = context.deploy_result
+    assert r.returncode == 0, (
+        f"Deploy failed (rc={r.returncode}):\n{r.stderr[:500]}"
+    )
+```
+
+---
+
+## Shell Command Steps (reusable)
+
+```python
+"""Step definitions for running CLI commands (DABs, databricks CLI)."""
+from __future__ import annotations
+
+import os
+import subprocess
+
+from behave import when, then
+from behave.runner import Context
+
+
+@when('I run "{command}" with target "{target}"')
+def step_run_command(context: Context, command: str, target: str) -> None:
+    full_cmd = f"{command} --target {target}"
+    context.cmd_result = subprocess.run(
+        full_cmd.split(),
+        capture_output=True,
+        text=True,
+        env={**dict(os.environ), "DATABRICKS_BUNDLE_ENGINE": "direct"},
+        timeout=300,
+    )
+
+
+@when('I run "{command}" with target "{target}" and auto-approve')
+def step_run_command_approve(context: Context, command: str, target: str) -> None:
+    full_cmd = f"{command} --target {target} --auto-approve"
+    context.cmd_result = subprocess.run(
+        full_cmd.split(),
+        capture_output=True,
+        text=True,
+        env={**dict(os.environ), "DATABRICKS_BUNDLE_ENGINE": "direct"},
+        timeout=300,
+    )
+
+
+@then("the command should exit with code {code:d}")
+def step_exit_code(context: Context, code: int) -> None:
+    actual = context.cmd_result.returncode
+    assert actual == code, (
+        f"Expected exit code {code}, got {actual}.\n"
+        f"stdout: {context.cmd_result.stdout[:300]}\n"
+        f"stderr: {context.cmd_result.stderr[:300]}"
+    )
+
+
+@then("the command should succeed")
+def step_command_success(context: Context) -> None:
+    assert context.cmd_result.returncode == 0, (
+        f"Command failed (rc={context.cmd_result.returncode}):\n"
+        f"{context.cmd_result.stderr[:500]}"
+    )
+```


### PR DESCRIPTION
## Summary

Adds four Claude Code skills for behaviour-driven development on Databricks. Pure addition — no production code changes, zero risk to existing deployments.

- **bdd-scaffold**: generates a complete Behave project wired to the Databricks SDK — `behave.ini`, `features/`, `steps/`, `environment.py`, `pyproject.toml` with UV
- **bdd-features**: writes Gherkin feature files using Databricks-specific patterns (Unity Catalog operations, pipeline runs, SQL assertions)
- **bdd-steps**: generates Python step definitions from feature files using the Databricks SDK step library
- **bdd-run**: executes Behave suites with tag filtering, parallel mode, and CI-friendly reporting

Includes a reference test suite for UC catalog and SQL operations in `.claude/skills/bdd-scaffold/test-suite/`.

## Test plan

- [ ] In a CODA instance, run `/bdd-scaffold` on a new project — confirm project structure is generated
- [ ] Run `/bdd-features` on a sample schema — confirm valid Gherkin output
- [ ] No production code changed — diff is 100% markdown + Gherkin + Python step examples

This pull request and its description were written by Isaac.