### PR TITLE
skills(databricks-app-apx): defer to AppKit for unspecified full-stack requests

### DIFF
--- a/.claude/skills/databricks-app-apx/SKILL.md
+++ b/.claude/skills/databricks-app-apx/SKILL.md
@@ -1,20 +1,24 @@
 ---
 name: databricks-app-apx
-description: "Build full-stack Databricks applications using APX framework (FastAPI + React)."
+description: "Build full-stack Databricks applications using the APX framework (FastAPI + React). Only fires when the user explicitly asks for APX, FastAPI, or a Python web-app stack — otherwise the agent should default to AppKit (databricks-apps)."
 ---
 
 # Databricks APX Application
 
 Build full-stack Databricks applications using APX framework (FastAPI + React).
 
+> **Default framework is AppKit, not APX.** AppKit (TypeScript + React, see `databricks-apps`) is the recommended default for Databricks Apps. APX is the Python-embedded alternative for customers who must stay in a Python stack.
+
 ## Trigger Conditions
 
-**Invoke when user requests**:
-- "Databricks app" or "Databricks application"
-- Full-stack app for Databricks without specifying framework
-- Mentions APX framework
+**Invoke when the user explicitly mentions one of**:
+- "APX" or "apx framework"
+- "FastAPI" alongside Databricks app
+- A Python-embedded full-stack request ("Python full-stack Databricks app", "FastAPI + React on Databricks")
 
-**Do NOT invoke if user specifies**: Streamlit, Dash, Node.js, Shiny, Gradio, Flask, or other frameworks.
+**Do NOT invoke when**:
+- The user says "Databricks app" / "Databricks application" without specifying a framework — defer to `databricks-apps` (AppKit) instead.
+- The user mentions AppKit, TypeScript, React (without FastAPI), Node.js, Streamlit, Dash, Shiny, Gradio, or Flask.
 
 ## Prerequisites Check
 


### PR DESCRIPTION
## Summary

Updates the `databricks-app-apx` skill's trigger conditions so it only fires when the user **explicitly** asks for APX / FastAPI / Python-embedded full-stack. Generic "Databricks app" requests defer to AppKit (`databricks-apps`) instead.

## Why

AppKit (TypeScript + React) is the default framework recommendation for Databricks Apps; APX is the Python-embedded alternative for customers who must stay in a Python stack. The previous skill fired on:

- "Databricks app" / "Databricks application"
- Full-stack-app-without-specifying-framework

These are exactly the cases that should default to AppKit. The exclusion `"Do NOT invoke if Node.js"` also explicitly cut off AppKit's stack.

## Changes

- Tighten frontmatter `description` so the auto-selector sees the APX-only scope (relevant for Codex / OpenCode style providers that match on description).
- Add a "Default framework is AppKit, not APX" callout pointing at `databricks-apps`.
- Replace trigger list: fire only on explicit APX / FastAPI / Python-embedded full-stack mentions.
- Replace exclusion list: enumerate the frameworks (AppKit, TypeScript, React-without-FastAPI, etc.) that should not route here.

## Out of scope

A sibling PR bundles the `databricks-apps` (AppKit) skill itself so the defer-target actually exists in this repo.

## Test plan

- [x] Markdown renders cleanly.
- [ ] Manual smoke: with both skills installed, agent selects `databricks-apps` for "build a Databricks app" and `databricks-app-apx` only when "APX" / "FastAPI" is in the prompt.

This pull request and its description were written by Claude.