### PR TITLE
skills(refresh-databricks-skills): repoint at databricks/databricks-agent-skills; drop stale ai-dev-kit refs

### DIFF
--- a/.claude/skills/refresh-databricks-skills/SKILL.md
+++ b/.claude/skills/refresh-databricks-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refresh-databricks-skills
-description: Use when Databricks skills need updating, user asks to refresh or sync skills from upstream, or skills seem outdated compared to the ai-dev-kit repo
+description: Use when Databricks skills need updating, user asks to refresh or sync skills from upstream, or skills seem outdated compared to the databricks-agent-skills repo
 ---
 
 # Refresh Databricks Skills
@@ -9,7 +9,9 @@ description: Use when Databricks skills need updating, user asks to refresh or s
 
 Pulls the latest Databricks skills from the upstream source repo and replaces all existing Databricks skills in the project while preserving non-Databricks skills (e.g., superpowers workflow skills).
 
-**Source repo:** `https://github.com/databricks-solutions/ai-dev-kit` (path: `databricks-skills/`)
+**Source repo:** `https://github.com/databricks/databricks-agent-skills` (paths: `skills/` for stable + `experimental/` for experimental).
+
+The upstream content was previously [`databricks-solutions/ai-dev-kit`](https://github.com/databricks-solutions/ai-dev-kit) (now deprecated). DAS is the canonical source going forward — stable skills live under `skills/` and experimental skills (the verbatim a-d-k snapshot) live under `experimental/`.
 
 ## When to Use
 
@@ -21,28 +23,33 @@ Pulls the latest Databricks skills from the upstream source repo and replaces al
 
 1. **Clone the upstream repo** (shallow clone for speed):
    ```bash
-   git clone --depth 1 https://github.com/databricks-solutions/ai-dev-kit.git $TMPDIR/ai-dev-kit
+   git clone --depth 1 https://github.com/databricks/databricks-agent-skills.git $TMPDIR/das
    ```
 
-2. **Identify non-Databricks skills to preserve.** These are the superpowers workflow skills that live alongside Databricks skills. List them by checking which directories in `.claude/skills/` do NOT have a matching folder in the upstream `databricks-skills/` directory. Common superpowers skills include: `brainstorming`, `dispatching-parallel-agents`, `executing-plans`, `finishing-a-development-branch`, `receiving-code-review`, `requesting-code-review`, `subagent-driven-development`, `systematic-debugging`, `test-driven-development`, `using-git-worktrees`, `using-superpowers`, `verification-before-completion`, `writing-plans`, `writing-skills`. Also preserve any other project-specific skills (like this one: `refresh-databricks-skills`).
+2. **Identify non-Databricks skills to preserve.** These are the superpowers workflow skills that live alongside Databricks skills. List them by checking which directories in `.claude/skills/` do NOT have a matching folder under `skills/` or `experimental/` in the upstream repo. Common superpowers skills include: `brainstorming`, `dispatching-parallel-agents`, `executing-plans`, `finishing-a-development-branch`, `receiving-code-review`, `requesting-code-review`, `subagent-driven-development`, `systematic-debugging`, `test-driven-development`, `using-git-worktrees`, `using-superpowers`, `verification-before-completion`, `writing-plans`, `writing-skills`. Also preserve any other project-specific skills (like this one: `refresh-databricks-skills`).
 
 3. **Remove old Databricks skills** from `.claude/skills/`, keeping all non-Databricks skills identified above.
 
-4. **Copy new Databricks skills** from the cloned repo. Copy every directory under `databricks-skills/` except `TEMPLATE`:
+4. **Copy new Databricks skills** from the cloned repo. Copy every directory under both `skills/` (stable) and `experimental/`:
    ```bash
    SKILLS_DIR=".claude/skills"
-   UPSTREAM="$TMPDIR/ai-dev-kit/databricks-skills"
-   for dir in "$UPSTREAM"/databricks-* "$UPSTREAM"/spark-*; do
-     [ -d "$dir" ] && cp -r "$dir" "$SKILLS_DIR/$(basename "$dir")"
+   UPSTREAM_STABLE="$TMPDIR/das/skills"
+   UPSTREAM_EXPERIMENTAL="$TMPDIR/das/experimental"
+   for src in "$UPSTREAM_STABLE" "$UPSTREAM_EXPERIMENTAL"; do
+     for dir in "$src"/databricks-* "$src"/spark-*; do
+       [ -d "$dir" ] && cp -r "$dir" "$SKILLS_DIR/$(basename "$dir")"
+     done
    done
    ```
 
+   Note: name collisions across `skills/` and `experimental/` are impossible — DAS's `scripts/skills.py` rejects them at generate-time.
+
 5. **Clean up** the cloned repo:
    ```bash
-   rm -rf $TMPDIR/ai-dev-kit
+   rm -rf $TMPDIR/das
    ```
 
-6. **Report** the count of skills added, removed, and updated.
+6. **Report** the count of skills added, removed, and updated, and call out whether each added skill came from `skills/` (stable) or `experimental/`.
 
 ## After Refreshing
 
@@ -54,6 +61,8 @@ databricks apps deploy <app-name> --source-code-path <workspace-path> --profile 
 
 ## Common Mistakes
 
+- **Pointing at the deprecated upstream:** Old versions of this skill cloned `databricks-solutions/ai-dev-kit`. That repo is deprecated and no longer receives skill updates — always use `databricks/databricks-agent-skills`.
+- **Forgetting `experimental/`:** DAS splits skills into `skills/` (stable, reviewed) and `experimental/` (best-effort a-d-k import). Both directories must be copied or you'll regress functionality.
 - **Deleting non-Databricks skills:** Always identify and preserve superpowers and project-specific skills before removing anything.
 - **Forgetting this skill itself:** `refresh-databricks-skills` must be preserved during the refresh.
 - **Not using `--depth 1`:** Full clone is slow and unnecessary. Always shallow clone.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Real-time terminal I/O over **WebSocket** (Flask-SocketIO) with automatic **HTTP
 
 ## Credits
 
-- Databricks skills from [databricks-solutions/ai-dev-kit](https://github.com/databricks-solutions/ai-dev-kit)
+- Databricks skills from [databricks/databricks-agent-skills](https://github.com/databricks/databricks-agent-skills) (canonical source; the legacy [databricks-solutions/ai-dev-kit](https://github.com/databricks-solutions/ai-dev-kit) is deprecated)
 - Development workflow skills from [obra/superpowers](https://github.com/obra/superpowers)
 
 # things to remember

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This template repo opens that vision up for every Databricks user — no IDE set
 <details>
 <summary><strong>🧠 All 39 Skills</strong></summary>
 
-### Databricks Skills (25) — [ai-dev-kit](https://github.com/databricks-solutions/ai-dev-kit)
+### Databricks Skills (25) — [databricks-agent-skills](https://github.com/databricks/databricks-agent-skills)
 
 | Category | Skills |
 |----------|--------|


### PR DESCRIPTION
## Summary

`refresh-databricks-skills` previously cloned `databricks-solutions/ai-dev-kit` to pick up the latest Databricks skills. That repo is **deprecated** — `databricks/databricks-agent-skills` (DAS) is the canonical upstream. This PR repoints the skill and updates two other stale a-d-k references.

## Why

- a-d-k stopped receiving skill updates; DAS is where the current content lives (stable skills in `skills/`, the verbatim a-d-k snapshot continues in DAS `experimental/`).
- Running the meta skill against the deprecated repo will eventually break (when the repo is archived) and already pulls stale content.
- CODA's CLAUDE.md and README.md still credited a-d-k as the source — drift from the actual upstream.

## Changes

- `.claude/skills/refresh-databricks-skills/SKILL.md` — switch the clone URL and update the copy loop to walk both `skills/` (stable) and `experimental/` (best-effort imports). Update the description to reference DAS. Add a "Pointing at deprecated upstream" common-mistake entry.
- `CLAUDE.md` — update "Credits" to name DAS and note a-d-k is deprecated.
- `README.md` — replace `ai-dev-kit` link in the skills section header with the DAS link.

## Out of scope

Auto-refresh on container start — that needs a `refresh_skills.py` wired into `run_setup()` in `app.py`, plus an opt-in env var. Follow-up.

## Test plan

- [x] Markdown renders cleanly.
- [ ] Manual: run the meta skill end-to-end against DAS and verify `.claude/skills/` ends up populated with both stable and experimental content.

This pull request and its description were written by Claude.