### PR TITLE
setup(codex/hermes/opencode): mirror Claude skills so non-Claude agents are not skill-blind

### DIFF
--- a/setup_codex.py
+++ b/setup_codex.py
@@ -13,7 +13,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from utils import adapt_instructions_file, ensure_https, get_gateway_host, get_npm_version
+from utils import adapt_instructions_file, ensure_https, get_gateway_host, get_npm_version, mirror_claude_skills
 
 # Set HOME if not properly set
 if not os.environ.get("HOME") or os.environ["HOME"] == "/":
@@ -92,6 +92,9 @@ else:
 # 3. Create ~/.codex directory and write config.toml
 codex_dir = home / ".codex"
 codex_dir.mkdir(exist_ok=True)
+
+# Mirror Claude skills into ~/.codex/skills so Codex sees the same skill content
+mirror_claude_skills(codex_dir / "skills", "Codex")
 
 # Copy bundled Databricks model catalog into ~/.codex so it can be referenced
 # by relative path in config.toml (codex resolves relatives against CODEX_HOME).

--- a/setup_hermes.py
+++ b/setup_hermes.py
@@ -25,7 +25,7 @@ import os
 import subprocess
 from pathlib import Path
 
-from utils import adapt_instructions_file, ensure_https, get_gateway_host
+from utils import adapt_instructions_file, ensure_https, get_gateway_host, mirror_claude_skills
 
 # Opt-out: allow operators to disable Hermes bundling without removing the file.
 if os.environ.get("ENABLE_HERMES", "true").strip().lower() in ("false", "0", "no"):
@@ -57,6 +57,9 @@ HERMES_EXTRA_DEPS = ["mcp>=1.2.0"]
 local_bin = home / ".local" / "bin"
 local_bin.mkdir(parents=True, exist_ok=True)
 hermes_home.mkdir(parents=True, exist_ok=True)
+
+# Mirror Claude skills into ~/.hermes/skills so Hermes sees the same skill content
+mirror_claude_skills(hermes_home / "skills", "Hermes")
 
 
 def _run(cmd, **kwargs):

--- a/setup_opencode.py
+++ b/setup_opencode.py
@@ -11,7 +11,7 @@ import json
 import subprocess
 from pathlib import Path
 
-from utils import ensure_https, get_gateway_host, get_npm_version
+from utils import ensure_https, get_gateway_host, get_npm_version, mirror_claude_skills
 
 # content-filter proxy local proxy — sanitizes empty content blocks before reaching Databricks
 # (see https://github.com/sst/opencode/issues/5028)
@@ -277,6 +277,9 @@ print(f"OpenCode configured: {config_path}")
 # OpenCode stores credentials at ~/.local/share/opencode/auth.json
 opencode_data_dir = home / ".local" / "share" / "opencode"
 opencode_data_dir.mkdir(parents=True, exist_ok=True)
+
+# Mirror Claude skills into ~/.local/share/opencode/skills so OpenCode sees them
+mirror_claude_skills(opencode_data_dir / "skills", "OpenCode")
 
 if gateway_host:
     auth_data = {

--- a/utils.py
+++ b/utils.py
@@ -4,8 +4,27 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import subprocess
 from pathlib import Path
+
+
+def mirror_claude_skills(target_dir: Path, agent_name: str) -> None:
+    """Mirror ~/.claude/skills into ``target_dir`` so non-Claude agents see them.
+
+    Replaces ``target_dir`` if it already exists (idempotent across restarts).
+    Resolves the Claude skills directory via ``HOME``, falling back to a no-op
+    if nothing is there (the same shape `setup_gemini.py` uses for Gemini).
+    """
+    home = Path(os.environ.get("HOME", "/app/python/source_code"))
+    claude_skills_dir = home / ".claude" / "skills"
+    if not claude_skills_dir.exists():
+        print(f"No Claude skills at {claude_skills_dir}, skipping {agent_name} mirror")
+        return
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    shutil.copytree(claude_skills_dir, target_dir)
+    print(f"Skills mirrored: {claude_skills_dir} -> {target_dir}")
 
 
 def get_npm_version(package_name):


### PR DESCRIPTION
## Summary

CODA bundles 43 skills under `.claude/skills/`, but only Claude Code consumed them. Codex, Hermes, and OpenCode didn't have the same Databricks knowledge available under their home dirs.

Adds a `mirror_claude_skills(target_dir, agent_name)` utility and wires it into the three setup scripts that didn't already do this. `setup_gemini.py` already mirrored to `~/.gemini/skills/`; left alone in this PR to keep the diff minimal.

## Changes

- `utils.py` — add `mirror_claude_skills(target_dir, agent_name)`. Idempotent (replaces target). Skips if `~/.claude/skills/` is absent.
- `setup_codex.py` — mirror to `~/.codex/skills/`.
- `setup_hermes.py` — mirror to `~/.hermes/skills/`.
- `setup_opencode.py` — mirror to `~/.local/share/opencode/skills/`.

## Caveats

Whether each agent *auto-discovers* the mirrored skills depends on the agent. The mirror at least guarantees the markdown content is on-disk under the agent's home — so the agent can browse / load on demand and the user can reference them by path. Per-agent auto-discovery (manifest registration, hook wiring) is a follow-up where the upstream agent supports it.

A future cleanup pass can route `setup_gemini.py` through the same helper for consistency.

## Test plan

- [x] `python -m py_compile setup_codex.py setup_hermes.py setup_opencode.py` clean.
- [x] `from utils import mirror_claude_skills` imports cleanly.
- [ ] Manual: deploy a fresh CODA container and confirm `~/.codex/skills/`, `~/.hermes/skills/`, `~/.local/share/opencode/skills/` exist and contain the expected skills after `run_setup()`.

This pull request and its description were written by Claude.